### PR TITLE
fix(nccl): increased nccl timeout

### DIFF
--- a/autoware_ml/configs/detection3d/default_runtime.py
+++ b/autoware_ml/configs/detection3d/default_runtime.py
@@ -12,7 +12,7 @@ default_hooks = dict(
 env_cfg = dict(
     cudnn_benchmark=False,
     mp_cfg=dict(mp_start_method="fork", opencv_num_threads=0),
-    dist_cfg=dict(backend="nccl"),
+    dist_cfg=dict(backend="nccl", timeout=7200),
 )
 
 log_processor = dict(type="LogProcessor", window_size=50, by_epoch=True)


### PR DESCRIPTION
## Summary

During the BEVFusion deployment I made several changed that are not yet in the main branch.
To keep track of the changes, I will split it in several self contained PRs.

In this one, I increased the timeout from nccl, which is triggered by the metrics evaluation taking over  10 minutes (600s seems to be the default value).

## Change point

Increased the timeout of nccl

Related error:
https://stackoverflow.com/questions/69693950/error-some-nccl-operations-have-failed-or-timed-out

If you add new feature or fix for core library

- feat(autoware-ml): add {feature name}
- fix(autoware-ml): fix {fixed point}

## Note

It applies to all 3d detection config files, but does not affect (negatively) their runtime .

## Test performed

- Training with two gpus worked when previously it used to failed during evaluation in the first epoch (note: during the first few epochs evaluation tends to take longer due to a high number of false positives)

