### PR TITLE
feat(validation): Add dynamic_intervals in CenterPoint, BevFusion and TransFusion

### DIFF
--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-CL-offline/bevfusion_camera_lidar_voxel_second_secfpn_2xb2_t4offline_no_intensity.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-CL-offline/bevfusion_camera_lidar_voxel_second_secfpn_2xb2_t4offline_no_intensity.py
@@ -443,7 +443,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-CL/bevfusion_camera_lidar_voxel_second_secfpn_1xb1_t4xx1.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-CL/bevfusion_camera_lidar_voxel_second_secfpn_1xb1_t4xx1.py
@@ -436,7 +436,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-L-offline/bevfusion_lidar_voxel_second_secfpn_1xb1_t4offline.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-L-offline/bevfusion_lidar_voxel_second_secfpn_1xb1_t4offline.py
@@ -358,7 +358,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-L-offline/bevfusion_lidar_voxel_second_secfpn_2xb2_t4offline_no_intensity.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-L-offline/bevfusion_lidar_voxel_second_secfpn_2xb2_t4offline_no_intensity.py
@@ -361,7 +361,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-L/bevfusion_lidar_voxel_second_secfpn_1xb1_t4xx1.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-L/bevfusion_lidar_voxel_second_secfpn_1xb1_t4xx1.py
@@ -352,7 +352,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/CenterPoint-ConvNeXtPC/pillar_020_convnext_small_secfpn_4xb8_121m_base.py
+++ b/projects/CenterPoint/configs/t4dataset/CenterPoint-ConvNeXtPC/pillar_020_convnext_small_secfpn_4xb8_121m_base.py
@@ -46,7 +46,7 @@ train_gpu_size = 4
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 2
+val_interval = 5
 max_epochs = 30
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/pillar_020_convnext_small_secfpn_4xb8_121m_base"
 
@@ -354,7 +354,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/CenterPoint-ConvNeXtPC/pillar_020_convnext_standard_secfpn_4xb8_121m_base.py
+++ b/projects/CenterPoint/configs/t4dataset/CenterPoint-ConvNeXtPC/pillar_020_convnext_standard_secfpn_4xb8_121m_base.py
@@ -46,7 +46,7 @@ train_gpu_size = 4
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 2
+val_interval = 5
 max_epochs = 30
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/pillar_020_convnext_standard_secfpn_4xb8_121m_base"
 
@@ -354,7 +354,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/CenterPoint-ShortRange/pillar_016_second_secfpn_2xb8_50m_base.py
+++ b/projects/CenterPoint/configs/t4dataset/CenterPoint-ShortRange/pillar_016_second_secfpn_2xb8_50m_base.py
@@ -44,7 +44,7 @@ train_gpu_size = 2
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 2
+val_interval = 5
 max_epochs = 50
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/pillar_016_second_secfpn_2xb8_50m_base/"
 
@@ -345,7 +345,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_base.py
+++ b/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_base.py
@@ -45,7 +45,7 @@ train_gpu_size = 2
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 1
+val_interval = 5
 max_epochs = 50
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/second_secfpn_2xb8_121m_base/"
 
@@ -346,7 +346,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_x2.py
+++ b/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_x2.py
@@ -45,7 +45,7 @@ train_gpu_size = 2
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 1
+val_interval = 5
 max_epochs = 50
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/second_secfpn_2xb8_121m_base/"
 
@@ -346,7 +346,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before 40th epoch, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_xx1.py
+++ b/projects/CenterPoint/configs/t4dataset/Centerpoint/second_secfpn_2xb8_121m_xx1.py
@@ -45,7 +45,7 @@ train_gpu_size = 2
 train_batch_size = 8
 test_batch_size = 2
 num_workers = 32
-val_interval = 1
+val_interval = 5
 max_epochs = 50
 work_dir = "work_dirs/centerpoint/" + _base_.dataset_type + "/second_secfpn_2xb8_121m_xx1/"
 
@@ -346,7 +346,10 @@ param_scheduler = [
 ]
 
 # runtime settings
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs, val_interval=val_interval)
+# Run validation for every val_interval epochs before max_epochs - 10, and run validation every 2 epoch after max_epochs - 10
+train_cfg = dict(
+    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
+)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4base.py
+++ b/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4base.py
@@ -111,7 +111,7 @@ visualizer = dict(
     name="visualizer",
 )
 
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs)
+train_cfg = dict(by_epoch=True, max_epochs=max_epochs, dynamic_intervals=[(max_epochs - 10, 2)])
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4x2-base.py
+++ b/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4x2-base.py
@@ -111,7 +111,7 @@ visualizer = dict(
     name="visualizer",
 )
 
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs)
+train_cfg = dict(by_epoch=True, max_epochs=max_epochs, dynamic_intervals=[(max_epochs - 10, 2)])
 val_cfg = dict()
 test_cfg = dict()
 

--- a/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4xx1-base.py
+++ b/projects/TransFusion/configs/t4dataset/default/dataset/transfusion_lidar_pillar_second_secfpn_1xb1_t4xx1-base.py
@@ -111,7 +111,7 @@ visualizer = dict(
     name="visualizer",
 )
 
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs)
+train_cfg = dict(by_epoch=True, max_epochs=max_epochs, dynamic_intervals=[(max_epochs - 10, 2)])
 val_cfg = dict()
 test_cfg = dict()
 


### PR DESCRIPTION
## Summary
Basically, it's more important to check validation performance at the last few epochs instead of every constant epoch. It also shouldn't run validation too frequent at the early stage of training. 
This PR adds `dynamic_intervals` in `[(num_epoch, dynamic_val_interval)]` to run validation before `num_epoch` for every `val_inteval`, and it runs validation for every `dynamic_val_interval` after `num_epoch`.

For example, 
```
val_interval = 5
max_epochs = 50
train_cfg = dict(
    by_epoch=True, max_epochs=max_epochs, val_interval=val_interval, dynamic_intervals=[(max_epochs - 10, 2)]
)
```
This will run validation for every 5 epoch before 40th epoch, and every 2 epoch after 40th epoch

We only add this to CenterPoint, BevFusion, and TranFusion
