### PR TITLE
feat(deploy_to_autoware): rework metadata script

### DIFF
--- a/tools/deploy_to_autoware/README.md
+++ b/tools/deploy_to_autoware/README.md
@@ -9,7 +9,7 @@ This script injects extra meta information.
 - Run
 
 ```sh
-python tools/deploy_to_autoware/update_onnx_metadata.py {path to onnx file} --domain "3D object detection" --version "CenterPoint base/1.0"
+python tools/deploy_to_autoware/update_onnx_metadata.py {path to onnx file} --version 1 --doc_string "Example additional description"
 ```
 
 By this update, logs in Autoware log files or /rosout topic can have model metadata.
@@ -18,11 +18,11 @@ By this update, logs in Autoware log files or /rosout topic can have model metad
 [autoware_lidar_centerpoint_node-1] [I] [TRT] Input filename:   /home/autoware/autoware_data/lidar_centerpoint/pts_backbone_neck_head_centerpoint_tiny.onnx
 [autoware_lidar_centerpoint_node-1] [I] [TRT] ONNX IR version:  0.0.6
 [autoware_lidar_centerpoint_node-1] [I] [TRT] Opset version:    11
-[autoware_lidar_centerpoint_node-1] [I] [TRT] Producer name:    autoware-ml
-[autoware_lidar_centerpoint_node-1] [I] [TRT] Producer version: v0.7.1
-[autoware_lidar_centerpoint_node-1] [I] [TRT] Domain:           3D object detection
-[autoware_lidar_centerpoint_node-1] [I] [TRT] Model version:    7
-[autoware_lidar_centerpoint_node-1] [I] [TRT] Doc string:       v3.2.3
+[autoware_lidar_centerpoint_node-1] [I] [TRT] Producer name:    AWML
+[autoware_lidar_centerpoint_node-1] [I] [TRT] Producer version: v1.0.0
+[autoware_lidar_centerpoint_node-1] [I] [TRT] Domain:           ai.onnx
+[autoware_lidar_centerpoint_node-1] [I] [TRT] Model version:    1
+[autoware_lidar_centerpoint_node-1] [I] [TRT] Doc string:       Example additional description
 ```
 
 ## [TBD] Generate ROS parameter

--- a/tools/deploy_to_autoware/update_onnx_metadata.py
+++ b/tools/deploy_to_autoware/update_onnx_metadata.py
@@ -5,20 +5,22 @@ from argparse import ArgumentParser
 import git
 import onnx
 
-DOMAINS = ["3D object detection", "3D object semantic segmentation"]
 
-
-def parse_args() -> ArgumentParser:
+def get_parser() -> ArgumentParser:
     parser = ArgumentParser()
     parser.add_argument("onnx_path", type=str, help="Path to input ONNX model file.")
-    parser.add_argument("--domain", type=str, choices=DOMAINS, help="Model domain.")
+    parser.add_argument(
+        "--domain",
+        choices=["ai.onnx"],
+        default="ai.onnx",
+        help="Namespace identifying the operator set used in the ONNX model.",
+    )
     parser.add_argument("--version", type=int, help="Model version.")
     parser.add_argument("--doc_string", type=str, help="Model description.")
     parser.add_argument("--output", type=str, help="Path to save updated ONNX file.")
     parser.add_argument("--use_hash", action="store_true", help="Use git hash as version instead of tag.")
 
-    args = parser.parse_args()
-    return args
+    return parser
 
 
 def log_meta_info(model: onnx.ModelProto, title: str = "") -> None:
@@ -42,7 +44,7 @@ def update_meta_info(
     if doc_string:
         model.doc_string = doc_string
 
-    model.producer_name = "autoware-ml"
+    model.producer_name = "AWML"
     model.producer_version = git.Repo(search_parent_directories=False).head.object.hexsha
 
     if use_hash:
@@ -60,7 +62,8 @@ def save_onnx_model(model: onnx.ModelProto, output_path: str) -> None:
 
 
 def main():
-    args = parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
 
     model = onnx.load(args.onnx_path)
 


### PR DESCRIPTION
## Summary

An update for metadata info script. 

## Change point

Latest PR just added script without deeper investigation. This PR refines meta information settings in order to achieve an appropriate logging during Autoware runtime.

## Note

Domain field refers to ONNX operator set, not task type. So far we use default operator set, therefore `ai.onnx` is the only choice (see https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions).

## Test performed

- Log

```
Log output
```
