### PR TITLE
docs(CenterPoint): add evaluation result for base/1.1

### DIFF
--- a/projects/CenterPoint/docs/CenterPoint/v1/base.md
+++ b/projects/CenterPoint/docs/CenterPoint/v1/base.md
@@ -14,7 +14,7 @@
 | CenterPoint base/1.5     | 66.7 | 80.1              | 54.3                | 79.1             | 55.3                 | 64.3                     |
 | CenterPoint base/1.4     | 66.3 | 80.5              | 53.1                | 81.1             | 52.0                 | 64.7                     |
 | CenterPoint base/1.3     | 66.7 | 80.6              | 53.5                | 80.2             | 54.3                 | 64.6                     |
-| CenterPoint base/1.1     | 61.6 | 77.5              | 50.3                | 68.8             | 50.5                 | 60.7                     |
+| CenterPoint base/1.1     | 63.5 | 77.7              | 50.3                | 76.5             | 51.9                 | 60.8                     |
 
 ## Deprecated summary
 <details>
@@ -455,15 +455,15 @@
   - train time: NVIDIA A100 80GB * 2 * 50 epochs = 4.5 days
 
 - Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 + db_j6_v5 + db_j6gen2_v1 (total frames: 3804)
-  - Total mAP (eval range = 120m): 0.616
+  - Total mAP (eval range = 120m): 0.635
 
 | class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
 | ---------- | ---- | ------- | ------- | ------- | ------- |
-| car        | 77.5 | 69.4    | 78.5    | 80.7    | 81.6    |
-| truck      | 50.3 | 30.4    | 50.2    | 57.5    | 63.2    |
-| bus        | 68.8 | 60.2    | 70.2    | 71.8    | 72.9    |
-| bicycle    | 50.5 | 49.8    | 50.7    | 50.7    | 50.8    |
-| pedestrian | 60.7 | 58.7    | 59.8    | 61.4    | 62.9    |
+| car        | 77.7 | 69.6    | 78.7    | 80.9    | 81.8    |
+| truck      | 50.3 | 30.3    | 49.8    | 57.0    | 63.9    |
+| bus        | 76.5 | 65.2    | 78.5    | 80.9    | 81.5    |
+| bicycle    | 51.9 | 51.0    | 52.0    | 52.1    | 52.6    |
+| pedestrian | 60.8 | 58.8    | 60.0    | 61.4    | 63.2    |
 
 - Evaluation result with test-dataset: db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 (total frames: 3026):
   - Total mAP (eval range = 120m): 0.647

--- a/projects/CenterPoint/docs/CenterPoint/v1/base.md
+++ b/projects/CenterPoint/docs/CenterPoint/v1/base.md
@@ -416,17 +416,6 @@
 <details>
 <summary> The link of data and evaluation result </summary>
 
-- Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 + db_j6_v5 + db_j6gen2_v1 (total frames: 3804)
-  - Total mAP (eval range = 120m): 0.616
-
-| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
-| ---------- | ---- | ------- | ------- | ------- | ------- |
-| car        | 77.5 | 69.4    | 78.5    | 80.7    | 81.6    |
-| truck      | 50.3 | 30.4    | 50.2    | 57.5    | 63.2    |
-| bus        | 68.8 | 60.2    | 70.2    | 71.8    | 72.9    |
-| bicycle    | 50.5 | 49.8    | 50.7    | 50.7    | 50.8    |
-| pedestrian | 60.7 | 58.7    | 59.8    | 61.4    | 62.9    |
-
 - Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 (total frames: 3026):
 
 | Eval range = 120m  | mAP  | car  | truck | bus  | bicycle | pedestrian |
@@ -464,6 +453,18 @@
     - [checkpoint_best.pth](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/centerpoint/centerpoint/t4base/v1.1/epoch_50.pth)
     - [config.py](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/centerpoint/centerpoint/t4base/v1.1/second_secfpn_121m_2xb8.py)
   - train time: NVIDIA A100 80GB * 2 * 50 epochs = 4.5 days
+
+- Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 + db_j6_v5 + db_j6gen2_v1 (total frames: 3804)
+  - Total mAP (eval range = 120m): 0.616
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---------- | ---- | ------- | ------- | ------- | ------- |
+| car        | 77.5 | 69.4    | 78.5    | 80.7    | 81.6    |
+| truck      | 50.3 | 30.4    | 50.2    | 57.5    | 63.2    |
+| bus        | 68.8 | 60.2    | 70.2    | 71.8    | 72.9    |
+| bicycle    | 50.5 | 49.8    | 50.7    | 50.7    | 50.8    |
+| pedestrian | 60.7 | 58.7    | 59.8    | 61.4    | 62.9    |
+
 - Evaluation result with test-dataset: db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 (total frames: 3026):
   - Total mAP (eval range = 120m): 0.647
 

--- a/projects/CenterPoint/docs/CenterPoint/v1/base.md
+++ b/projects/CenterPoint/docs/CenterPoint/v1/base.md
@@ -14,6 +14,7 @@
 | CenterPoint base/1.5     | 66.7 | 80.1              | 54.3                | 79.1             | 55.3                 | 64.3                     |
 | CenterPoint base/1.4     | 66.3 | 80.5              | 53.1                | 81.1             | 52.0                 | 64.7                     |
 | CenterPoint base/1.3     | 66.7 | 80.6              | 53.5                | 80.2             | 54.3                 | 64.6                     |
+| CenterPoint base/1.1     | 61.6 | 77.5              | 50.3                | 68.8             | 50.5                 | 60.7                     |
 
 ## Deprecated summary
 <details>
@@ -414,6 +415,17 @@
 
 <details>
 <summary> The link of data and evaluation result </summary>
+
+- Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 + db_j6_v5 + db_j6gen2_v1 (total frames: 3804)
+  - Total mAP (eval range = 120m): 0.616
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---------- | ---- | ------- | ------- | ------- | ------- |
+| car        | 77.5 | 69.4    | 78.5    | 80.7    | 81.6    |
+| truck      | 50.3 | 30.4    | 50.2    | 57.5    | 63.2    |
+| bus        | 68.8 | 60.2    | 70.2    | 71.8    | 72.9    |
+| bicycle    | 50.5 | 49.8    | 50.7    | 50.7    | 50.8    |
+| pedestrian | 60.7 | 58.7    | 59.8    | 61.4    | 62.9    |
 
 - Evaluation result with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 (total frames: 3026):
 


### PR DESCRIPTION
## Summary

Add comparison result for base/1.1 with db_jpntaxi_v1 + db_jpntaxi_v2 + db_jpntaxi_v4 + db_gsm8_v1 + db_j6_v1 + db_j6_v2 + db_j6_v3 + db_j6_v5 + db_j6gen2_v1 (total frames: 3804)

Link to evaluation log: [TIER IV INTERNAL LINK](https://drive.google.com/drive/folders/15nyLlj44oZ8HMCBGv7K-Aw8tlGLBjzzO?usp=drive_link)

## Change point

- docs(CenterPoint): add evaluation result for base/1.1

## Note

This PR does not influence other project.

