### PR TITLE
chore(bevfusion): added additional evaluation info for base1.0

### DIFF
--- a/projects/BEVFusion/docs/BEVFusion-CL/v1/base.md
+++ b/projects/BEVFusion/docs/BEVFusion-CL/v1/base.md
@@ -10,16 +10,20 @@
 
 - We release LiDAR only model trained with base1.0 dataset
 
-|                       | mAP  | car  | truck | bus  | bicycle | pedestrian |
-| --------------------- | ---- | ---- | ----- | ---- | ------- | ---------- |
-| BEVFusion-CL base/1.0 | 66.9 |  80.6 | 65.65 | 59.7 | 68.8    | 60.2       |
-| BEVFusion-L base/1.0  | 63.7 |  72.3 | 58.8  | 70.5 | 70.2    | 56.3       |
+|                              | mAP  | car  | truck | bus  | bicycle | pedestrian |
+| ---------------------------  | ---- | ---- | ----- | ---- | ------- | ---------- |
+| BEVFusion-CL base/1.0 (ALL)  | 66.9 |  80.6 | 65.65 | 59.7 | 68.8    | 60.2       |
+| BEVFusion-L base/1.0 (ALL)   | 63.7 |  72.3 | 58.8  | 70.5 | 70.2    | 56.3       |
+| BEVFusion-CL base/1.0  (TAXI)| 68.5 |  76.0 | 64.9  | 68.6 | 73.2    | 60.1       |
+| BEVFusion-L base/1.0  (TAXI) | 68.2 |  75.6 | 63.2  | 71.5 | 70.0    | 60.6       |
+| BEVFusion-CL base/1.0  (BUS) | 63.3 |  70.8 | 55.7  | 64.8 | 69.9    | 55.9       |
+| BEVFusion-L base/1.0  (BUS)  | 63.8 |  70.7 | 55.2  | 69.9 | 70.3    | 52.9       |
 
 <details>
 <summary> The link of data and evaluation result </summary>
 
 - model
-  - Training dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v3.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 34,137)
+  - Training dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v4.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 34,137)
   - [Config file path](https://github.com/tier4/AWML/blob/05302ecc9e832f3c988019f5d30fdfc105455027/projects/BEVFusion/configs/t4dataset/bevfusion_camera_lidar_voxel_second_secfpn_1xb1_t4xx1.py)
   - Training results [model-zoo]
     - [logs.zip](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/bevfusion/bevfusion-cl/t4base/v1.0/logs.zip)
@@ -27,7 +31,7 @@
     - [checkpoint_latest.pth](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/bevfusion/bevfusion-cl/t4base/v1.0/epoch_40.pth)
     - [config.py](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/bevfusion/bevfusion-cl/t4base/v1.0/bevfusion_camera_lidar_voxel_second_secfpn_l4_2xb4_base_1.0.py)
   - train time: NVIDIA A100 80GB * 2 * 40 epochs = 4.5 days
-  - Evaluation result with test-dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v3.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 1,394):
+  - Evaluation result with test-dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v4.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 2787):
 
 | class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
 | ---- | ---- | ---- | ---- | ---- | ---- |
@@ -36,5 +40,25 @@
 | bus        | 59.7 | 30.8    | 58.1    | 72.3    | 77.4    |
 | bicycle    | 68.8 | 65.8    | 69.5    | 69.8    | 70.2    |
 | pedestrian | 60.2 | 51.2    | 58.3    | 63.6    | 67.8    |
+
+  - Evaluation result with test-dataset (bus only): DB GSM8 v1.0 + DB J6 v1.0 (total frames: 1280):
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| car        | 70.8 | 57.9    | 70.5    | 76.3    | 78.6    |
+| truck      | 55.7 | 27.5    | 53.2    | 65.6    | 76.3    |
+| bus        | 64.8 | 38.4    | 65.8    | 76.0    | 78.9    |
+| bicycle    | 69.4 | 66.9    | 69.8    | 70.2    | 70.8    |
+| pedestrian | 55.9 | 45.0    | 51.5    | 59.8    | 67.3    |
+
+  - Evaluation result with test-dataset (taxi only): DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v4.0  (total frames: 1507):
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| car        | 76.0 | 55.9    | 77.3    | 83.9    | 86.7    |
+| truck      | 64.9 | 35.2    | 62.1    | 78.8    | 83.4    |
+| bus        | 68.6 | 41.7    | 70.8    | 78.7    | 83.2    |
+| bicycle    | 73.2 | 68.4    | 74.4    | 74.9    | 75.1    |
+| pedestrian | 60.1 | 48.6    | 58.5    | 64.7    | 68.6    |
 
 </details>

--- a/projects/BEVFusion/docs/BEVFusion-L/v1/base.md
+++ b/projects/BEVFusion/docs/BEVFusion-L/v1/base.md
@@ -11,10 +11,14 @@
 
 - We release LiDAR only model trained with base1.0 dataset
 
-|                       | mAP  | car  | truck | bus  | bicycle | pedestrian |
-| --------------------- | ---- | ---- | ----- | ---- | ------- | ---------- |
-| BEVFusion-CL base/1.0 | 66.9 |  80.6 | 65.65 | 59.7 | 68.8    | 60.2       |
-| BEVFusion-L base/1.0  | 63.7 |  72.3 | 58.8  | 70.5 | 70.2    | 56.3       |
+|                              | mAP  | car  | truck | bus  | bicycle | pedestrian |
+| ---------------------------  | ---- | ---- | ----- | ---- | ------- | ---------- |
+| BEVFusion-CL base/1.0 (ALL)  | 66.9 |  80.6 | 65.65 | 59.7 | 68.8    | 60.2       |
+| BEVFusion-L base/1.0 (ALL)   | 63.7 |  72.3 | 58.8  | 70.5 | 70.2    | 56.3       |
+| BEVFusion-CL base/1.0  (TAXI)| 68.5 |  76.0 | 64.9  | 68.6 | 73.2    | 60.1       |
+| BEVFusion-L base/1.0  (TAXI) | 68.2 |  75.6 | 63.2  | 71.5 | 70.0    | 60.6       |
+| BEVFusion-CL base/1.0  (BUS) | 63.3 |  70.8 | 55.7  | 64.8 | 69.9    | 55.9       |
+| BEVFusion-L base/1.0  (BUS)  | 63.8 |  70.7 | 55.2  | 69.9 | 70.3    | 52.9       |
 
 <details>
 <summary> The link of data and evaluation result </summary>
@@ -28,7 +32,7 @@
     - [checkpoint_latest.pth](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/bevfusion/bevfusion-l/t4base/v1.0/epoch_50.pth)
     - [config.py](https://download.autoware-ml-model-zoo.tier4.jp/autoware-ml/models/bevfusion/bevfusion-l/t4base/v1.0/bevfusion_lidar_voxel_second_secfpn_l4_2xb4_base_1.0.py)
   - train time: NVIDIA A100 80GB * 2 * 40 epochs = 4.5 days
-  - Evaluation result with test-dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v3.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 1,394):
+  - Evaluation result with test-dataset: DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v4.0 + DB GSM8 v1.0 + DB J6 v1.0 (total frames: 2787):
 
 | class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
 | ---- | ---- | ---- | ---- | ---- | ---- |
@@ -37,5 +41,25 @@
 | bus        | 70.5 | 42.9    | 71.0    | 83.0    | 85.4    |
 | bicycle    | 70.2 | 66.4    | 71.0    | 71.4    | 71.9    |
 | pedestrian | 56.3 | 46.8    | 53.5    | 59.8    | 65.0    |
+
+  - Evaluation result with test-dataset (bus only): DB GSM8 v1.0 + DB J6 v1.0 (total frames: 1280):
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| car        | 70.7 | 57.4    | 70.4    | 76.4    | 78.5    |
+| truck      | 55.2 | 23.2    | 52.9    | 67.2    | 77.5    |
+| bus        | 69.9 | 41.9    | 70.8    | 82.7    | 84.3    |
+| bicycle    | 70.3 | 68.3    | 70.4    | 70.8    | 71.5    |
+| pedestrian | 52.9 | 43.8    | 49.0    | 56.1    | 62.8    |
+
+  - Evaluation result with test-dataset (taxi only): DB JPNTAXI v1.0 + DB JPNTAXI v2.0 + DB JPNTAXI v4.0  (total frames: 1507):
+
+| class_name | mAP  | AP@0.5m | AP@1.0m | AP@2.0m | AP@4.0m |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| car        | 75.6 | 55.4    | 77.0    | 83.6    | 86.5    |
+| truck      | 63.2 | 33.4    | 60.8    | 76.5    | 82.0    |
+| bus        | 71.5 | 44.2    | 72.7    | 82.9    | 86.4    |
+| bicycle    | 70.0 | 59.7    | 73.0    | 73.5    | 73.7    |
+| pedestrian | 60.6 | 50.8    | 59.4    | 64.4    | 67.9    |
 
 </details>


### PR DESCRIPTION
## Summary

Performed some more evaluation for base1.0 BEVFusion models.

## Change point

Specifically, evaluated the base1.0 BEVFusion models separately on taxi and bus data to get finer evaluation results and make better comparision between fusion and lidar only models.
|                              | mAP  | car  | truck | bus  | bicycle | pedestrian |
| ---------------------------  | ---- | ---- | ----- | ---- | ------- | ---------- |
| BEVFusion-CL base/1.0  (TAXI)| 68.5 |  76.0 | 64.9  | 68.6 | 73.2    | 60.1       |
| BEVFusion-L base/1.0  (TAXI) | 68.2 |  75.6 | 63.2  | 71.5 | 70.0    | 60.6       |
| BEVFusion-CL base/1.0  (BUS) | 63.3 |  70.8 | 55.7  | 64.8 | 69.9    | 55.9       |
| BEVFusion-L base/1.0  (BUS)  | 63.8 |  70.7 | 55.2  | 69.9 | 70.3    | 52.9       |

Check the details HERE: 
https://github.com/tier4/AWML/blob/03ae17bef27946b8743adbc7f378818545617273/projects/BEVFusion/docs/BEVFusion-CL/v1/base.md
https://github.com/tier4/AWML/blob/03ae17bef27946b8743adbc7f378818545617273/projects/BEVFusion/docs/BEVFusion-L/v1/base.md

## Test performed

Only docs were changed, so no tests performed.