### PR TITLE
feat(dataset): add new dataset to DB J6Gen2 v3.0

### DIFF
--- a/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
+++ b/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
@@ -18,6 +18,7 @@ train:
   - f9656f2e-5ce5-4ed5-a29d-4cb29ee5079e
   - 3bcce97a-86c3-4d38-a691-7293ec2afb20
   - 65641e4a-b537-4148-9a7c-c354906aabf2
+  - 691a503f-3c8d-4ae3-a973-9a278338a7fc
 
 val: []
 

--- a/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
+++ b/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
@@ -17,6 +17,7 @@ train:
   - 39588227-5a55-45c5-9b7b-a1500ec0db8c
   - f9656f2e-5ce5-4ed5-a29d-4cb29ee5079e
   - 3bcce97a-86c3-4d38-a691-7293ec2afb20
+  - 65641e4a-b537-4148-9a7c-c354906aabf2
 
 val: []
 

--- a/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
+++ b/autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml
@@ -12,6 +12,11 @@ train:
   - ea4ea9c1-d3c7-44b7-b4db-c91bfbbb5de3
   - de9ad1f3-d651-45b7-a378-247b2add3a25
   - c722439d-7a46-4a23-9aa8-abebb99d430d
+  - aa5c8d52-fd06-4fe9-80a8-1290a9883161
+  - 594cc5dc-538f-48cf-a579-94e94d25d563
+  - 39588227-5a55-45c5-9b7b-a1500ec0db8c
+  - f9656f2e-5ce5-4ed5-a29d-4cb29ee5079e
+  - 3bcce97a-86c3-4d38-a691-7293ec2afb20
 
 val: []
 


### PR DESCRIPTION
## Summary

Add new dataset to `DB J6Gen2 v3.0`

## Change point

- feat(autoware-ml): add dataset

## Note

This PR influences the dataset used for gen2.

## Test performed

- I confirmed that you can download dataset successfully if you have the webauto licence.
  - The log is below.

<details>
<summary>output from download command</summary>

```bash
shin@ubuntu:~/AWML$ python3 pipelines/webauto/download_t4dataset/download_t4dataset.py autoware_ml/configs/t4dataset/db_j6gen2_v3.yaml --output /mnt/nvme1n1/tier4_dataset/ --project-id x2_dev --delete-rosbag

***** Start downloading T4Dataset ID:e4359aff-ea82-4ff0-860b-9ad24808cfd2 with version:0
webauto data annotation-dataset pull --project-id x2_dev --annotation-dataset-id e4359aff-ea82-4ff0-860b-9ad24808cfd2 --asset-dir /tmp/tmp3ajbtp97
downloading the vector map of area map [1847-20250612053811146725] to /tmp/tmp3ajbtp97/annotation_dataset/e4359aff-ea82-4ff0-860b-9ad24808cfd2/0/map
...
```

</details>
