### PR TITLE
feat(t4dataset): add option to filter missing image frames

### DIFF
--- a/autoware_ml/detection3d/datasets/t4dataset.py
+++ b/autoware_ml/detection3d/datasets/t4dataset.py
@@ -1,12 +1,13 @@
 import gc
 import pickle
 from os import path as osp
+from typing import List
 
 import numpy as np
 from mmdet3d.datasets import NuScenesDataset
 from mmengine.logging import print_log
 from mmengine.registry import DATASETS
-from typing import List
+
 
 @DATASETS.register_module()
 class T4Dataset(NuScenesDataset):
@@ -54,7 +55,7 @@ class T4Dataset(NuScenesDataset):
             return self.data_list
         filtered_data_list = []
         for entry in self.data_list:
-            if self.filter_cfg.get("filter_frames_with_missing_image",False) and not all(
+            if self.filter_cfg.get("filter_frames_with_missing_image", False) and not all(
                 [x["img_path"] and osp.exists(x["img_path"]) for x in entry["images"].values()]
             ):
                 continue

--- a/autoware_ml/detection3d/datasets/t4dataset.py
+++ b/autoware_ml/detection3d/datasets/t4dataset.py
@@ -1,5 +1,7 @@
 from os import path as osp
 
+import gc
+import pickle
 import numpy as np
 from mmdet3d.datasets import NuScenesDataset
 from mmengine.logging import print_log
@@ -9,7 +11,19 @@ from mmengine.registry import DATASETS
 @DATASETS.register_module()
 class T4Dataset(NuScenesDataset):
     """T4Dataset Dataset base class
-    The descriptions below are for the methods that aren't implemented this class.
+    
+    This dataset class extends NuScenesDataset to provide specialized functionality
+    for T4 dataset processing with additional filtering and validation capabilities.
+    
+    Args:
+        metainfo: Metadata information for the dataset.
+        class_names: List of class names for object detection/classification.
+        use_valid_flag (bool, optional): Whether to use validity flags for filtering 
+            annotations. Defaults to False.
+        filter_frames_with_missing_image (bool, optional): Whether to filter out 
+            frames that have missing image data. Defaults to False. Used for trianing models that use 
+            images.
+        **kwargs: Additional keyword arguments passed to the parent NuScenesDataset.
     """
 
     def __init__(
@@ -17,14 +31,56 @@ class T4Dataset(NuScenesDataset):
         metainfo,
         class_names,
         use_valid_flag: bool = False,
+        filter_frames_with_missing_image: bool = False,
         **kwargs,
     ):
         T4Dataset.METAINFO = metainfo
         self.valid_class_name_ins = {class_name: 0 for class_name in class_names}
         self.class_names = class_names
+        self.filter_frames_with_missing_image = filter_frames_with_missing_image 
         super().__init__(use_valid_flag=use_valid_flag, **kwargs)
         print_log(f"Valid dataset instances: {self.valid_class_name_ins}", logger="current")
 
+    def _serialize_data(self):
+        """ 
+        Overriding from superclass.
+
+        Serialize ``self.data_list`` to save memory when launching multiple
+        workers in data loading. This function will be called in ``full_init``.
+
+        Hold memory using serialized objects, and data loader workers can use
+        shared RAM from master process instead of making a copy.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Serialized result and corresponding
+            address.
+        """
+
+        def _serialize(data):
+            buffer = pickle.dumps(data, protocol=4)
+            return np.frombuffer(buffer, dtype=np.uint8)
+
+        def _validate_entry(info):
+            if self.filter_frames_with_missing_image and not all([x["img_path"] and osp.exists(x["img_path"]) for x in info["images"].values()]):
+                return False
+            return True
+
+        # Serialize data information list avoid making multiple copies of
+        # `self.data_list` when iterate `import torch.utils.data.dataloader`
+        # with multiple workers.
+        serialized_data_list = [_serialize(entry) for entry in self.data_list if _validate_entry(entry)]
+        if len(serialized_data_list)!=len(self.data_list):
+            print(f"Filtered {len(self.data_list)-len(serialized_data_list)}/{len(self.data_list)} frames without images.")
+        address_list = np.asarray([len(x) for x in serialized_data_list], dtype=np.int64)
+        data_address: np.ndarray = np.cumsum(address_list)
+        data_bytes = np.concatenate(serialized_data_list)
+
+        # Empty cache for preventing making multiple copies of
+        # `self.data_info` when loading data multi-processes.
+        self.data_list.clear()
+        gc.collect()
+        return data_bytes, data_address
+        
     def _filter_with_mask(self, ann_info: dict) -> dict:
         """Remove annotations that do not need to be cared.
 

--- a/autoware_ml/detection3d/datasets/t4dataset.py
+++ b/autoware_ml/detection3d/datasets/t4dataset.py
@@ -74,7 +74,7 @@ class T4Dataset(NuScenesDataset):
         if len(serialized_data_list) != len(self.data_list):
             print_log(
                 f"Filtered {len(self.data_list)-len(serialized_data_list)}/{len(self.data_list)} frames without images.",
-                logger="current"
+                logger="current",
             )
         address_list = np.asarray([len(x) for x in serialized_data_list], dtype=np.int64)
         data_address: np.ndarray = np.cumsum(address_list)

--- a/autoware_ml/detection3d/datasets/t4dataset.py
+++ b/autoware_ml/detection3d/datasets/t4dataset.py
@@ -21,7 +21,7 @@ class T4Dataset(NuScenesDataset):
         use_valid_flag (bool, optional): Whether to use validity flags for filtering
             annotations. Defaults to False.
         filter_frames_with_missing_image (bool, optional): Whether to filter out
-            frames that have missing image data. Defaults to False. Used for trianing models that use
+            frames that have missing image data. Defaults to False. Used for training models that use
             images.
         **kwargs: Additional keyword arguments passed to the parent NuScenesDataset.
     """
@@ -72,8 +72,9 @@ class T4Dataset(NuScenesDataset):
         # with multiple workers.
         serialized_data_list = [_serialize(entry) for entry in self.data_list if _validate_entry(entry)]
         if len(serialized_data_list) != len(self.data_list):
-            print(
-                f"Filtered {len(self.data_list)-len(serialized_data_list)}/{len(self.data_list)} frames without images."
+            print_log(
+                f"Filtered {len(self.data_list)-len(serialized_data_list)}/{len(self.data_list)} frames without images.",
+                logger="current"
             )
         address_list = np.asarray([len(x) for x in serialized_data_list], dtype=np.int64)
         data_address: np.ndarray = np.cumsum(address_list)

--- a/autoware_ml/detection3d/datasets/t4dataset.py
+++ b/autoware_ml/detection3d/datasets/t4dataset.py
@@ -34,7 +34,6 @@ class T4Dataset(NuScenesDataset):
         T4Dataset.METAINFO = metainfo
         self.valid_class_name_ins = {class_name: 0 for class_name in class_names}
         self.class_names = class_names
-        self.filter_frames_with_missing_image = filter_frames_with_missing_image
         super().__init__(use_valid_flag=use_valid_flag, **kwargs)
         print_log(f"Valid dataset instances: {self.valid_class_name_ins}", logger="current")
 


### PR DESCRIPTION
## Summary

Adds an option `filter_frames_with_missing_image` to T4Dataset to filter out frames that do not contain some images in the. Useful for training models that use images.

## Test performed

Performed local tests with the new feature turned on and off.
