### PR TITLE
feat(T4Metric): Add dataset-base evaluation to script

### DIFF
--- a/autoware_ml/configs/detection3d/dataset/t4dataset/gen2_base.py
+++ b/autoware_ml/configs/detection3d/dataset/t4dataset/gen2_base.py
@@ -15,6 +15,12 @@ info_test_file_name = "t4dataset_gen2_base_infos_test.pkl"
 dataset_version_config_root = "autoware_ml/configs/t4dataset/"
 dataset_version_list = ["db_j6gen2_v1", "db_j6gen2_v2", "db_j6gen2_v4", "db_largebus_v1"]
 
+dataset_test_groups = {
+	"db_j6gen2": "t4dataset_j6gen2_infos_test.pkl",
+	"db_largebus": "t4dataset_largebus_infos_test.pkl",
+    "db_gen2_base": "t4dataset_gen2_base_infos_test.pkl",
+}
+
 # dataset format setting
 data_prefix = dict(pts="", sweeps="")
 camera_types = {

--- a/autoware_ml/configs/detection3d/dataset/t4dataset/gen2_base.py
+++ b/autoware_ml/configs/detection3d/dataset/t4dataset/gen2_base.py
@@ -16,8 +16,8 @@ dataset_version_config_root = "autoware_ml/configs/t4dataset/"
 dataset_version_list = ["db_j6gen2_v1", "db_j6gen2_v2", "db_j6gen2_v4", "db_largebus_v1"]
 
 dataset_test_groups = {
-	"db_j6gen2": "t4dataset_j6gen2_infos_test.pkl",
-	"db_largebus": "t4dataset_largebus_infos_test.pkl",
+    "db_j6gen2": "t4dataset_j6gen2_infos_test.pkl",
+    "db_largebus": "t4dataset_largebus_infos_test.pkl",
     "db_gen2_base": "t4dataset_gen2_base_infos_test.pkl",
 }
 

--- a/autoware_ml/detection3d/evaluation/t4metric/t4metric.py
+++ b/autoware_ml/detection3d/evaluation/t4metric/t4metric.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import tempfile
 from os import path as osp
@@ -32,6 +33,8 @@ class T4Metric(NuScenesMetric):
         self,
         data_root: str,
         ann_file: str,
+        save_csv: bool = False,
+        dataset_name: str = "base",
         filter_attributes: Optional[List[Tuple[str, str]]] = None,
         metric: Union[str, List[str]] = "bbox",
         modality: dict = dict(use_camera=False, use_lidar=True),
@@ -52,6 +55,9 @@ class T4Metric(NuScenesMetric):
                 Path of dataset root.
             ann_file (str):
                 Path of annotation file.
+            save_csv (bool): Set True to save metrics to csv files.
+            dataset_name (str):
+                Dataset name running this T4Metric.
             filter_attributes (str)
                 Filter out GTs with certain attributes. For example, [['vehicle.bicycle',
                 'vehicle_state.parked']].
@@ -106,7 +112,8 @@ class T4Metric(NuScenesMetric):
             collect_device=collect_device,
             backend_args=backend_args,
         )
-
+        self.save_csv = save_csv
+        self.dataset_name = dataset_name
         self.class_names = class_names
         self.version = version
 
@@ -285,7 +292,7 @@ class T4Metric(NuScenesMetric):
             )
             # record metrics
             metrics = load(os.path.join(output_dir, "metrics_summary.json"))
-            detail = self._create_detail(metrics, classes)
+            detail = self._create_detail(metrics=metrics, classes=classes, logger=logger, save_csv=self.save_csv)
             all_detail.update(detail)
         return all_detail
 
@@ -369,11 +376,20 @@ class T4Metric(NuScenesMetric):
 
         # record metrics
         metrics = load(os.path.join(output_dir, "metrics_summary.json"))
-        detail = self._create_detail(metrics, classes)
+        detail = self._create_detail(metrics=metrics, classes=classes, save_csv=False)
 
         return detail, preds, gt_boxes
 
-    def _create_detail(self, metrics: dict, classes: Optional[List[str]]) -> Dict[str, float]:
+    def _write_to_csv(self, header, data, csv_filename: str, logger) -> None:
+        """"""
+        with open(csv_filename, "w") as f:
+          writer = csv.writer(f)
+          writer.writerow(header)
+          for row in data:
+            writer.writerow(row)
+        print_log(f"Saved in {csv_filename}", logger=logger)
+
+    def _create_detail(self, metrics: dict, classes: Optional[List[str]], logger = None, save_csv: bool = False) -> Dict[str, float]:
         """Create a dictionary to store the details of the evaluation.
 
         Returns:
@@ -395,6 +411,49 @@ class T4Metric(NuScenesMetric):
 
         detail[f"{metric_prefix}/NDS"] = metrics["nd_score"]
         detail[f"{metric_prefix}/mAP"] = metrics["mean_ap"]
+
+        if save_csv:
+          log_file_path = logger.handlers[1].baseFilename
+          log_dir = os.path.dirname(log_file_path)
+
+          score_headers = ["NDS", "mAP"]
+          score_data = [float(f"{metrics['nd_score']:.4f}"), float(f"{metrics['mean_ap']:.4f}")]
+          for k, v in metrics["tp_errors"].items():
+            val = float(f"{v:.4f}")
+            score_headers.append(self.ErrNameMapping[k])
+            score_data.append(val)
+
+          csv_filename = osp.join(log_dir, f"scores_{self.dataset_name}.csv")
+          self._write_to_csv(header=score_headers, data=[score_data], csv_filename=csv_filename, logger=logger)
+
+          class_ap_headers = ["class", "mAP"]
+          mean_ap = metrics["mean_dist_aps"]
+          class_ap_data = []
+          if classes is not None:
+            first_class = classes[0]
+            for k in metrics["label_aps"][first_class].keys():
+                header = f"AP_dist_{k}"
+                class_ap_headers.append(header)
+
+            for k in metrics["label_tp_errors"][first_class].keys():
+                class_ap_headers.append(k)
+
+            for name in classes:
+                ap_data = [name, float(f"{mean_ap[name] * 100.0:.4f}")]
+
+                for k, v in metrics["label_aps"][name].items():
+                    val = float(f"{v*100:.4f}")
+                    ap_data.append(val)
+
+                for k, v in metrics["label_tp_errors"][name].items():
+                    val = float(f"{v:.4f}")
+                    ap_data.append(val)
+
+                class_ap_data.append(ap_data)
+
+            csv_filename = osp.join(log_dir, f"class_ap_{self.dataset_name}.csv")
+            self._write_to_csv(header=class_ap_headers, data=class_ap_data, csv_filename=csv_filename, logger=logger)
+            
         return detail
 
     def format_results(

--- a/autoware_ml/detection3d/evaluation/t4metric/t4metric.py
+++ b/autoware_ml/detection3d/evaluation/t4metric/t4metric.py
@@ -383,13 +383,15 @@ class T4Metric(NuScenesMetric):
     def _write_to_csv(self, header, data, csv_filename: str, logger) -> None:
         """"""
         with open(csv_filename, "w") as f:
-          writer = csv.writer(f)
-          writer.writerow(header)
-          for row in data:
-            writer.writerow(row)
+            writer = csv.writer(f)
+            writer.writerow(header)
+            for row in data:
+                writer.writerow(row)
         print_log(f"Saved in {csv_filename}", logger=logger)
 
-    def _create_detail(self, metrics: dict, classes: Optional[List[str]], logger = None, save_csv: bool = False) -> Dict[str, float]:
+    def _create_detail(
+        self, metrics: dict, classes: Optional[List[str]], logger=None, save_csv: bool = False
+    ) -> Dict[str, float]:
         """Create a dictionary to store the details of the evaluation.
 
         Returns:
@@ -413,47 +415,49 @@ class T4Metric(NuScenesMetric):
         detail[f"{metric_prefix}/mAP"] = metrics["mean_ap"]
 
         if save_csv:
-          log_file_path = logger.handlers[1].baseFilename
-          log_dir = os.path.dirname(log_file_path)
+            log_file_path = logger.handlers[1].baseFilename
+            log_dir = os.path.dirname(log_file_path)
 
-          score_headers = ["NDS", "mAP"]
-          score_data = [float(f"{metrics['nd_score']:.4f}"), float(f"{metrics['mean_ap']:.4f}")]
-          for k, v in metrics["tp_errors"].items():
-            val = float(f"{v:.4f}")
-            score_headers.append(self.ErrNameMapping[k])
-            score_data.append(val)
+            score_headers = ["NDS", "mAP"]
+            score_data = [float(f"{metrics['nd_score']:.4f}"), float(f"{metrics['mean_ap']:.4f}")]
+            for k, v in metrics["tp_errors"].items():
+                val = float(f"{v:.4f}")
+                score_headers.append(self.ErrNameMapping[k])
+                score_data.append(val)
 
-          csv_filename = osp.join(log_dir, f"scores_{self.dataset_name}.csv")
-          self._write_to_csv(header=score_headers, data=[score_data], csv_filename=csv_filename, logger=logger)
+            csv_filename = osp.join(log_dir, f"scores_{self.dataset_name}.csv")
+            self._write_to_csv(header=score_headers, data=[score_data], csv_filename=csv_filename, logger=logger)
 
-          class_ap_headers = ["class", "mAP"]
-          mean_ap = metrics["mean_dist_aps"]
-          class_ap_data = []
-          if classes is not None:
-            first_class = classes[0]
-            for k in metrics["label_aps"][first_class].keys():
-                header = f"AP_dist_{k}"
-                class_ap_headers.append(header)
+            class_ap_headers = ["class", "mAP"]
+            mean_ap = metrics["mean_dist_aps"]
+            class_ap_data = []
+            if classes is not None:
+                first_class = classes[0]
+                for k in metrics["label_aps"][first_class].keys():
+                    header = f"AP_dist_{k}"
+                    class_ap_headers.append(header)
 
-            for k in metrics["label_tp_errors"][first_class].keys():
-                class_ap_headers.append(k)
+                for k in metrics["label_tp_errors"][first_class].keys():
+                    class_ap_headers.append(k)
 
-            for name in classes:
-                ap_data = [name, float(f"{mean_ap[name] * 100.0:.4f}")]
+                for name in classes:
+                    ap_data = [name, float(f"{mean_ap[name] * 100.0:.4f}")]
 
-                for k, v in metrics["label_aps"][name].items():
-                    val = float(f"{v*100:.4f}")
-                    ap_data.append(val)
+                    for k, v in metrics["label_aps"][name].items():
+                        val = float(f"{v*100:.4f}")
+                        ap_data.append(val)
 
-                for k, v in metrics["label_tp_errors"][name].items():
-                    val = float(f"{v:.4f}")
-                    ap_data.append(val)
+                    for k, v in metrics["label_tp_errors"][name].items():
+                        val = float(f"{v:.4f}")
+                        ap_data.append(val)
 
-                class_ap_data.append(ap_data)
+                    class_ap_data.append(ap_data)
 
-            csv_filename = osp.join(log_dir, f"class_ap_{self.dataset_name}.csv")
-            self._write_to_csv(header=class_ap_headers, data=class_ap_data, csv_filename=csv_filename, logger=logger)
-            
+                csv_filename = osp.join(log_dir, f"class_ap_{self.dataset_name}.csv")
+                self._write_to_csv(
+                    header=class_ap_headers, data=class_ap_data, csv_filename=csv_filename, logger=logger
+                )
+
         return detail
 
     def format_results(

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -132,10 +132,10 @@ def main():
                 # if 'runner_type' is set in the cfg
                 runner = RUNNERS.build(cfg)
 
+            print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
+            
             # start testing
             runner.test()
-            print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
-
     else:
         # build the runner from config
         if "runner_type" not in cfg:

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -5,9 +5,9 @@ import os.path as osp
 
 from mmdet3d.utils import replace_ceph_backend
 from mmengine.config import Config, ConfigDict, DictAction
+from mmengine.logging import print_log
 from mmengine.registry import RUNNERS
 from mmengine.runner import Runner
-from mmengine.logging import print_log
 
 
 # TODO: support fuse_conv_bn and format_only

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -117,16 +117,37 @@ def main():
         cfg.model = ConfigDict(**cfg.tta_model, module=cfg.model)
 
     # build the runner from config
-    if "runner_type" not in cfg:
-        # build the default runner
-        runner = Runner.from_cfg(cfg)
-    else:
-        # build customized runner from the registry
-        # if 'runner_type' is set in the cfg
-        runner = RUNNERS.build(cfg)
+    if "dataset_test_groups" in cfg:
+      for dataset_name, dataset_file in cfg.dataset_test_groups.items():
+        cfg.test_dataloader.dataset.ann_file = osp.join(cfg.info_directory_path, dataset_file)
+        cfg.test_evaluator.dataset_name = dataset_name
+        cfg.test_evaluator.ann_file = osp.join(cfg.data_root, cfg.info_directory_path, dataset_file)
 
-    # start testing
-    runner.test()
+        # build the runner from config
+        if "runner_type" not in cfg:
+            # build the default runner
+            runner = Runner.from_cfg(cfg)
+        else:
+            # build customized runner from the registry
+            # if 'runner_type' is set in the cfg
+            runner = RUNNERS.build(cfg)
+
+        # start testing
+        runner.test()
+        print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
+
+    else:
+      # build the runner from config
+      if "runner_type" not in cfg:
+          # build the default runner
+          runner = Runner.from_cfg(cfg)
+      else:
+          # build customized runner from the registry
+          # if 'runner_type' is set in the cfg
+          runner = RUNNERS.build(cfg)
+
+      # start testing
+      runner.test()
 
 
 if __name__ == "__main__":

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -7,6 +7,7 @@ from mmdet3d.utils import replace_ceph_backend
 from mmengine.config import Config, ConfigDict, DictAction
 from mmengine.registry import RUNNERS
 from mmengine.runner import Runner
+from mmengine.logging import print_log
 
 
 # TODO: support fuse_conv_bn and format_only

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -133,7 +133,7 @@ def main():
                 runner = RUNNERS.build(cfg)
 
             print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
-            
+
             # start testing
             runner.test()
     else:

--- a/tools/detection3d/test.py
+++ b/tools/detection3d/test.py
@@ -118,11 +118,25 @@ def main():
 
     # build the runner from config
     if "dataset_test_groups" in cfg:
-      for dataset_name, dataset_file in cfg.dataset_test_groups.items():
-        cfg.test_dataloader.dataset.ann_file = osp.join(cfg.info_directory_path, dataset_file)
-        cfg.test_evaluator.dataset_name = dataset_name
-        cfg.test_evaluator.ann_file = osp.join(cfg.data_root, cfg.info_directory_path, dataset_file)
+        for dataset_name, dataset_file in cfg.dataset_test_groups.items():
+            cfg.test_dataloader.dataset.ann_file = osp.join(cfg.info_directory_path, dataset_file)
+            cfg.test_evaluator.dataset_name = dataset_name
+            cfg.test_evaluator.ann_file = osp.join(cfg.data_root, cfg.info_directory_path, dataset_file)
 
+            # build the runner from config
+            if "runner_type" not in cfg:
+                # build the default runner
+                runner = Runner.from_cfg(cfg)
+            else:
+                # build customized runner from the registry
+                # if 'runner_type' is set in the cfg
+                runner = RUNNERS.build(cfg)
+
+            # start testing
+            runner.test()
+            print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
+
+    else:
         # build the runner from config
         if "runner_type" not in cfg:
             # build the default runner
@@ -134,20 +148,6 @@ def main():
 
         # start testing
         runner.test()
-        print_log(f"Testing dataset: {dataset_name} with file: {dataset_file}", logger=runner.logger)
-
-    else:
-      # build the runner from config
-      if "runner_type" not in cfg:
-          # build the default runner
-          runner = Runner.from_cfg(cfg)
-      else:
-          # build customized runner from the registry
-          # if 'runner_type' is set in the cfg
-          runner = RUNNERS.build(cfg)
-
-      # start testing
-      runner.test()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This script adds an option to run several evaluation in one script so that our users can avoid running multiple scripts manually. It's a temporary solution before we integrate the new evaluation framework to `AWML`.

To use it, please specify the following configs to your experiment:
```
dataset_test_groups = {
	"db_j6gen2": "t4dataset_j6gen2_infos_test.pkl",
	"db_largebus": "t4dataset_largebus_infos_test.pkl",
        "db_gen2_base": "t4dataset_gen2_base_infos_test.pkl",
}

Can also specify `save_csv=True` to `test_evaluator` to save results to csv files.

```
  
## Test performed
Tested in H100 with recent experiments
