### PR TITLE
fix(tools): update to use dataset version id in create_data_t4dataset.py

### DIFF
--- a/tools/detection2d/create_data_t4dataset.py
+++ b/tools/detection2d/create_data_t4dataset.py
@@ -158,7 +158,7 @@ def main() -> None:
             print_log(f"Creating data info for split: {split}", logger="current")
             for scene_id in dataset_list_dict.get(split, []):
                 print_log(f"Creating data info for scene: {scene_id}")
-                
+
                 t4_dataset_id, t4_dataset_version_id = scene_id.split("   ")
                 if os.path.exists(osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)):
                     scene_root_dir_path = osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)

--- a/tools/detection2d/create_data_t4dataset.py
+++ b/tools/detection2d/create_data_t4dataset.py
@@ -87,6 +87,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", type=str, required=True, help="config for T4dataset")
     parser.add_argument("--root_path", type=str, required=True, help="specify the root path of dataset")
     parser.add_argument("--data_name", type=str, required=True, help="dataset name. example: tlr")
+    parser.add_argument(
+        "--use_available_dataset_version",
+        type=int,
+        required=True,
+        help="Will resort to using the available dataset version if the one specified in the config file does not exist.",
+    )
     parser.add_argument("-o", "--out_dir", type=str, required=True, help="output directory of info file")
     return parser.parse_args()
 
@@ -152,14 +158,18 @@ def main() -> None:
             print_log(f"Creating data info for split: {split}", logger="current")
             for scene_id in dataset_list_dict.get(split, []):
                 print_log(f"Creating data info for scene: {scene_id}")
-                scene_root_dir_path = get_scene_root_dir_path(
-                    args.root_path,
-                    dataset_version,
-                    scene_id,
-                )
+                
+                t4_dataset_id, t4_dataset_version_id = scene_id.split("   ")
+                if os.path.exists(osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)):
+                    scene_root_dir_path = osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)
+                elif args.use_available_dataset_version:
+                    print(
+                        "Warning: The version of the dataset specified in the config file does not exist. Will use whatever is available locally."
+                    )
+                    scene_root_dir_path = get_scene_root_dir_path(args.root_path, dataset_version, t4_dataset_id)
+                else:
+                    raise ValueError(f"{t4_dataset_id} does not exist.")
 
-                if not osp.isdir(scene_root_dir_path):
-                    raise ValueError(f"{scene_root_dir_path} does not exist.")
                 t4 = Tier4(
                     version="annotation",
                     data_root=scene_root_dir_path,

--- a/tools/detection2d/create_data_t4dataset.py
+++ b/tools/detection2d/create_data_t4dataset.py
@@ -89,8 +89,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--data_name", type=str, required=True, help="dataset name. example: tlr")
     parser.add_argument(
         "--use_available_dataset_version",
-        type=int,
-        required=True,
+        action="store_true",
         help="Will resort to using the available dataset version if the one specified in the config file does not exist.",
     )
     parser.add_argument("-o", "--out_dir", type=str, required=True, help="output directory of info file")

--- a/tools/detection3d/create_data_t4dataset.py
+++ b/tools/detection3d/create_data_t4dataset.py
@@ -256,19 +256,15 @@ def main():
                 print_log(f"Creating data info for scene: {scene_id}")
                 t4_dataset_id, t4_dataset_version_id = scene_id.split("   ")
                 if os.path.exists(osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)):
-                    scene_root_dir_path = osp.join(
-                        args.root_path, t4_dataset_id, t4_dataset_version_id
-                    )
+                    scene_root_dir_path = osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)
                 elif args.use_available_dataset_version:
-                    print("Warning: The version of the dataset specified in the config file does not exist. Will use whatever is available locally.")
-                    scene_root_dir_path = get_scene_root_dir_path(
-                        args.root_path,
-                        dataset_version,
-                        t4_dataset_id
+                    print(
+                        "Warning: The version of the dataset specified in the config file does not exist. Will use whatever is available locally."
                     )
+                    scene_root_dir_path = get_scene_root_dir_path(args.root_path, dataset_version, t4_dataset_id)
                 else:
                     raise ValueError(f"{t4_dataset_id} does not exist.")
-                    
+
                 t4 = Tier4(version="annotation", data_root=scene_root_dir_path, verbose=False)
                 for i, sample in enumerate(t4.sample):
                     info = get_info(cfg, t4, sample, i, args.max_sweeps)

--- a/tools/detection3d/create_data_t4dataset.py
+++ b/tools/detection3d/create_data_t4dataset.py
@@ -217,8 +217,7 @@ def parse_args():
     )
     parser.add_argument(
         "--use_available_dataset_version",
-        type=int,
-        required=True,
+        action="store_true",
         help="Will resort to using the available dataset version if the one specified in the config file does not exist.",
     )
     args = parser.parse_args()

--- a/tools/detection3d/create_data_t4dataset.py
+++ b/tools/detection3d/create_data_t4dataset.py
@@ -215,6 +215,12 @@ def parse_args():
         required=True,
         help="output directory of info file",
     )
+    parser.add_argument(
+        "--use_available_dataset_version",
+        type=int,
+        required=True,
+        help="Will resort to using the available dataset version if the one specified in the config file does not exist.",
+    )
     args = parser.parse_args()
     return args
 
@@ -248,14 +254,21 @@ def main():
             print_log(f"Creating data info for split: {split}", logger="current")
             for scene_id in dataset_list_dict.get(split, []):
                 print_log(f"Creating data info for scene: {scene_id}")
-                scene_root_dir_path = get_scene_root_dir_path(
-                    args.root_path,
-                    dataset_version,
-                    scene_id,
-                )
-
-                if not osp.isdir(scene_root_dir_path):
-                    raise ValueError(f"{scene_root_dir_path} does not exist.")
+                t4_dataset_id, t4_dataset_version_id = scene_id.split("   ")
+                if os.path.exists(osp.join(args.root_path, t4_dataset_id, t4_dataset_version_id)):
+                    scene_root_dir_path = osp.join(
+                        args.root_path, t4_dataset_id, t4_dataset_version_id
+                    )
+                elif args.use_available_dataset_version:
+                    print("Warning: The version of the dataset specified in the config file does not exist. Will use whatever is available locally.")
+                    scene_root_dir_path = get_scene_root_dir_path(
+                        args.root_path,
+                        dataset_version,
+                        t4_dataset_id
+                    )
+                else:
+                    raise ValueError(f"{t4_dataset_id} does not exist.")
+                    
                 t4 = Tier4(version="annotation", data_root=scene_root_dir_path, verbose=False)
                 for i, sample in enumerate(t4.sample):
                     info = get_info(cfg, t4, sample, i, args.max_sweeps)


### PR DESCRIPTION
## Summary

This PR updates the `create_data_t4dataset.py` file to work with the recent PR: https://github.com/tier4/AWML/pull/78
The dataset info files are created using the dataset version id specified in the config files. If the specified version is absent, an error is thrown, but if `--use_available_dataset_version` tag is passed, the script will use whatever version of dataset is available.


## Test performed

tested locally
