### PR TITLE
feat(fix): fix bevfusion ci deployment script

### DIFF
--- a/projects/BEVFusion/README.md
+++ b/projects/BEVFusion/README.md
@@ -131,7 +131,7 @@ python projects/BEVFusion/deploy/torch2onnx.py \
   ${MODEL_CFG} \
   ${CHECKPOINT_PATH} \
   --device cuda:0 \
-  --work-dir ${WORK_DIR}
+  --work-dir ${WORK_DIR} \
   --module main_body
 
 
@@ -140,7 +140,7 @@ python projects/BEVFusion/deploy/torch2onnx.py \
   ${MODEL_CFG} \
   ${CHECKPOINT_PATH} \
   --device cuda:0 \
-  --work-dir ${WORK_DIR}
+  --work-dir ${WORK_DIR} \
   --module image_backbone
 
 ```

--- a/projects/BEVFusion/bevfusion/bevfusion.py
+++ b/projects/BEVFusion/bevfusion/bevfusion.py
@@ -57,7 +57,7 @@ class BEVFusion(Base3DDetector):
 
         self.init_weights()
 
-    def _forward(self, batch_inputs_dict: Tensor, batch_data_samples: OptSampleList = None, **kwargs):
+    def _forward(self, batch_inputs_dict: Tensor, batch_data_samples: OptSampleList = [], using_image_features=False,**kwargs):
         """Network forward process.
 
         Usually includes backbone, neck and head forward without any post-
@@ -66,7 +66,7 @@ class BEVFusion(Base3DDetector):
 
         # NOTE(knzo25): this is used during onnx export
         batch_input_metas = [item.metainfo for item in batch_data_samples]
-        feats = self.extract_feat(batch_inputs_dict, batch_input_metas)
+        feats = self.extract_feat(batch_inputs_dict, batch_input_metas,using_image_features)
 
         if self.with_bbox_head:
             outputs = self.bbox_head(feats, batch_input_metas)
@@ -122,6 +122,21 @@ class BEVFusion(Base3DDetector):
         """bool: Whether the detector has a segmentation head."""
         return hasattr(self, "seg_head") and self.seg_head is not None
 
+    def get_image_backbone_features(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C, H, W = x.size()
+        x = x.view(B * N, C, H, W).contiguous()
+
+        x = self.img_backbone(x)
+        x = self.img_neck(x)
+
+        if not isinstance(x, torch.Tensor):
+            x = x[0]
+
+        BN, C, H, W = x.size()
+        assert BN == B * N, (BN, B * N)
+        x = x.view(B, N, C, H, W)
+        return x
+
     def extract_img_feat(
         self,
         x,
@@ -136,19 +151,11 @@ class BEVFusion(Base3DDetector):
         img_aug_matrix_inverse=None,
         lidar_aug_matrix_inverse=None,
         geom_feats=None,
+        using_image_features=False,
     ) -> torch.Tensor:
-        B, N, C, H, W = x.size()
-        x = x.view(B * N, C, H, W).contiguous()
 
-        x = self.img_backbone(x)
-        x = self.img_neck(x)
-
-        if not isinstance(x, torch.Tensor):
-            x = x[0]
-
-        BN, C, H, W = x.size()
-        assert BN == B * N, (BN, B * N)
-        x = x.view(B, N, C, H, W)
+        if not using_image_features:
+            x = self.get_image_backbone_features(x)
 
         with torch.cuda.amp.autocast(enabled=False):
             # with torch.autocast(device_type='cuda', dtype=torch.float32):
@@ -219,7 +226,8 @@ class BEVFusion(Base3DDetector):
         return feats, coords, sizes
 
     def predict(
-        self, batch_inputs_dict: Dict[str, Optional[Tensor]], batch_data_samples: List[Det3DDataSample], **kwargs
+        self, batch_inputs_dict: Dict[str, Optional[Tensor]], batch_data_samples: List[Det3DDataSample], 
+        using_image_features=False, **kwargs
     ) -> List[Det3DDataSample]:
         """Forward of testing.
 
@@ -246,7 +254,7 @@ class BEVFusion(Base3DDetector):
                 contains a tensor with shape (num_instances, 7).
         """
         batch_input_metas = [item.metainfo for item in batch_data_samples]
-        feats = self.extract_feat(batch_inputs_dict, batch_input_metas)
+        feats = self.extract_feat(batch_inputs_dict, batch_input_metas, using_image_features)
 
         if self.with_bbox_head:
             outputs = self.bbox_head.predict(feats, batch_input_metas)
@@ -259,6 +267,7 @@ class BEVFusion(Base3DDetector):
         self,
         batch_inputs_dict,
         batch_input_metas,
+        using_image_features,
         **kwargs,
     ):
         imgs = batch_inputs_dict.get("imgs", None)
@@ -290,6 +299,7 @@ class BEVFusion(Base3DDetector):
                 img_aug_matrix,
                 lidar_aug_matrix,
                 batch_input_metas,
+                using_image_features=using_image_features
             )
             features.append(img_feature)
         elif imgs is not None:
@@ -323,6 +333,7 @@ class BEVFusion(Base3DDetector):
                 lidar_aug_matrix,
                 batch_input_metas,
                 geom_feats=geom_feats,
+                using_image_features=using_image_features
             )
             features.append(img_feature)
 
@@ -346,10 +357,10 @@ class BEVFusion(Base3DDetector):
         return x
 
     def loss(
-        self, batch_inputs_dict: Dict[str, Optional[Tensor]], batch_data_samples: List[Det3DDataSample], **kwargs
+        self, batch_inputs_dict: Dict[str, Optional[Tensor]], batch_data_samples: List[Det3DDataSample], using_image_features:bool = False, **kwargs
     ) -> List[Det3DDataSample]:
         batch_input_metas = [item.metainfo for item in batch_data_samples]
-        feats = self.extract_feat(batch_inputs_dict, batch_input_metas)
+        feats = self.extract_feat(batch_inputs_dict, batch_input_metas,using_image_features)
 
         losses = dict()
         if self.with_bbox_head:

--- a/projects/BEVFusion/bevfusion/depth_lss.py
+++ b/projects/BEVFusion/bevfusion/depth_lss.py
@@ -314,20 +314,6 @@ class BaseDepthTransform(BaseViewTransform):
         lidar_aug_matrix_inverse,
         geom_feats_precomputed,
     ):
-        post_trans = img_aug_matrix[..., :3, 3]
-        camera2lidar_rots = camera2lidar[..., :3, :3]
-        camera2lidar_trans = camera2lidar[..., :3, 3]
-
-        if camera_intrinsics_inverse is None:
-            intrins_inverse = torch.inverse(cam_intrinsic)[..., :3, :3]
-        else:
-            intrins_inverse = camera_intrinsics_inverse[..., :3, :3]
-
-        if img_aug_matrix_inverse is None:
-            post_rots_inverse = torch.inverse(img_aug_matrix)[..., :3, :3]
-        else:
-            img_aug_matrix_inverse = img_aug_matrix_inverse[..., :3, :3]
-
         if lidar_aug_matrix_inverse is None:
             lidar_aug_matrix_inverse = torch.inverse(lidar_aug_matrix)
 
@@ -406,6 +392,20 @@ class BaseDepthTransform(BaseViewTransform):
 
             x = self.bev_pool_precomputed(x, geom_feats, kept, ranks, indices)
         else:
+            post_trans = img_aug_matrix[..., :3, 3]
+            camera2lidar_rots = camera2lidar[..., :3, :3]
+            camera2lidar_trans = camera2lidar[..., :3, 3]
+            
+            if camera_intrinsics_inverse is None:
+                intrins_inverse = torch.inverse(cam_intrinsic)[..., :3, :3]
+            else:
+                intrins_inverse = camera_intrinsics_inverse[..., :3, :3]
+            
+            if img_aug_matrix_inverse is None:
+                post_rots_inverse = torch.inverse(img_aug_matrix)[..., :3, :3]
+            else:
+                post_rots_inverse = img_aug_matrix_inverse[..., :3, :3]
+
             geom = self.get_geometry(
                 camera2lidar_rots,
                 camera2lidar_trans,

--- a/projects/BEVFusion/configs/deploy/bevfusion_camera_backbone_tensorrt_dynamic.py
+++ b/projects/BEVFusion/configs/deploy/bevfusion_camera_backbone_tensorrt_dynamic.py
@@ -9,41 +9,15 @@ custom_imports = dict(
     allow_failed_imports=False,
 )
 
+image_dims = (384,576)
+
 backend_config = dict(
     type="tensorrt",
     common_config=dict(max_workspace_size=1 << 32),
     model_inputs=[
         dict(
             input_shapes=dict(
-                imgs=dict(min_shape=[1, 3, 256, 704], opt_shape=[6, 3, 256, 704], max_shape=[6, 3, 256, 704]),
-                points=dict(min_shape=[5000, 5], opt_shape=[50000, 5], max_shape=[200000, 5]),
-                lidar2image=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                cam2image_inverse=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                camera2lidar=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                img_aug_matrix=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                img_aug_matrix_inverse=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                lidar_aug_matrix=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                lidar_aug_matrix_inverse=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
-                geom_feats=dict(
-                    min_shape=[0 * 118 * 32 * 88, 4],
-                    opt_shape=[6 * 118 * 32 * 88 // 2, 4],
-                    max_shape=[6 * 118 * 32 * 88, 4],
-                ),
-                kept=dict(
-                    min_shape=[0 * 118 * 32 * 88],
-                    opt_shape=[6 * 118 * 32 * 88],
-                    max_shape=[6 * 118 * 32 * 88],
-                ),
-                ranks=dict(
-                    min_shape=[0 * 118 * 32 * 88],
-                    opt_shape=[6 * 118 * 32 * 88 // 2],
-                    max_shape=[6 * 118 * 32 * 88],
-                ),
-                indices=dict(
-                    min_shape=[0 * 118 * 32 * 88],
-                    opt_shape=[6 * 118 * 32 * 88 // 2],
-                    max_shape=[6 * 118 * 32 * 88],
-                ),
+                imgs=dict(min_shape=[1, 3, image_dims[0], image_dims[1]], opt_shape=[6, 3, image_dims[0], image_dims[1]], max_shape=[6, 3, image_dims[0], image_dims[1]]),
             )
         )
     ],
@@ -57,64 +31,13 @@ onnx_config = dict(
     save_file="image_backbone.onnx",
     input_names=[
         "imgs",
-        "points",
-        "lidar2image",
-        "cam2image",
-        "cam2image_inverse",
-        "camera2lidar",
-        "img_aug_matrix",
-        "img_aug_matrix_inverse",
-        "lidar_aug_matrix",
-        "lidar_aug_matrix_inverse",
-        "geom_feats",
-        "kept",
-        "ranks",
-        "indices",
     ],
     output_names=["image_feats"],
     dynamic_axes={
         "imgs": {
             0: "num_imgs",
         },
-        "points": {
-            0: "num_points",
-        },
-        "lidar2image": {
-            0: "num_imgs",
-        },
-        "cam2image": {
-            0: "num_imgs",
-        },
-        "cam2image_inverse": {
-            0: "num_imgs",
-        },
-        "camera2lidar": {
-            0: "num_imgs",
-        },
-        "img_aug_matrix": {
-            0: "num_imgs",
-        },
-        "img_aug_matrix_inverse": {
-            0: "num_imgs",
-        },
-        "lidar_aug_matrix": {
-            0: "num_imgs",
-        },
-        "lidar_aug_matrix_inverse": {
-            0: "num_imgs",
-        },
-        "geom_feats": {
-            0: "num_kept",
-        },
-        "kept": {
-            0: "num_geom_feats",
-        },
-        "ranks": {
-            0: "num_kept",
-        },
-        "indices": {
-            0: "num_kept",
-        },
+
     },
     input_shape=None,
     verbose=True,

--- a/projects/BEVFusion/configs/deploy/bevfusion_main_body_lidar_only_tensorrt_dynamic.py
+++ b/projects/BEVFusion/configs/deploy/bevfusion_main_body_lidar_only_tensorrt_dynamic.py
@@ -15,8 +15,8 @@ backend_config = dict(
     model_inputs=[
         dict(
             input_shapes=dict(
-                voxels=dict(min_shape=[1, 5], opt_shape=[64000, 5], max_shape=[256000, 5]),
-                coors=dict(min_shape=[1, 4], opt_shape=[64000, 4], max_shape=[256000, 4]),
+                voxels=dict(min_shape=[1, 10, 4], opt_shape=[64000, 10, 4], max_shape=[256000, 10, 4]),
+                coors=dict(min_shape=[1, 3], opt_shape=[64000, 3], max_shape=[256000, 3]),
                 num_points_per_voxel=dict(min_shape=[1], opt_shape=[64000], max_shape=[256000]),
             )
         )

--- a/projects/BEVFusion/configs/deploy/bevfusion_main_body_with_image_tensorrt_dynamic.py
+++ b/projects/BEVFusion/configs/deploy/bevfusion_main_body_with_image_tensorrt_dynamic.py
@@ -9,6 +9,9 @@ custom_imports = dict(
     allow_failed_imports=False,
 )
 
+depth_bins = 118
+feature_dims = (48,72)
+
 backend_config = dict(
     type="tensorrt",
     common_config=dict(max_workspace_size=1 << 32),
@@ -18,7 +21,34 @@ backend_config = dict(
                 voxels=dict(min_shape=[1, 10, 4], opt_shape=[64000, 10, 4], max_shape=[256000, 10, 4]),
                 coors=dict(min_shape=[1, 3], opt_shape=[64000, 3], max_shape=[256000, 3]),
                 num_points_per_voxel=dict(min_shape=[1], opt_shape=[64000], max_shape=[256000]),
-                image_feats=dict(min_shape=[80, 180, 180], opt_shape=[80, 180, 180], max_shape=[80, 180, 180]),
+                # TODO(TIERIV): Optimize. Now, using points will increase latency significantly
+                # points=dict(min_shape=[5000, 4], opt_shape=[50000, 4], max_shape=[200000, 4]),
+                lidar2image=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
+                img_aug_matrix=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
+                geom_feats=dict(
+                    min_shape=[0 * depth_bins * feature_dims[0] * feature_dims[1], 4],   
+                    opt_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1] // 2, 4],
+                    max_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1], 4],
+                ),
+                kept=dict(
+                    min_shape=[0 * depth_bins * feature_dims[0] * feature_dims[1]],
+                    opt_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1]],
+                    max_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1]],
+                ),
+                ranks=dict(
+                    min_shape=[0 * depth_bins * feature_dims[0] * feature_dims[1]],
+                    opt_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1] // 2],
+                    max_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1]],
+                ),
+                indices=dict(
+                    min_shape=[0 * depth_bins * feature_dims[0] * feature_dims[1]],
+                    opt_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1] // 2],
+                    max_shape=[6 * depth_bins * feature_dims[0] * feature_dims[1]],
+                ),
+                image_feats=dict(
+                    min_shape=[0, 256, feature_dims[0], feature_dims[1]], 
+                    opt_shape=[6, 256, feature_dims[0], feature_dims[1]], 
+                    max_shape=[6, 256, feature_dims[0], feature_dims[1]]),
             )
         )
     ],
@@ -30,7 +60,19 @@ onnx_config = dict(
     keep_initializers_as_inputs=False,
     opset_version=17,
     save_file="main_body.onnx",
-    input_names=["voxels", "coors", "num_points_per_voxel", "image_feats"],
+    input_names=[
+        "voxels",
+        "coors",
+        "num_points_per_voxel",
+        # "points",
+        "lidar2image",
+        "img_aug_matrix",
+        "geom_feats",
+        "kept",
+        "ranks",
+        "indices",
+        "image_feats",
+    ],
     output_names=["bbox_pred", "score", "label_pred"],
     dynamic_axes={
         "voxels": {
@@ -41,6 +83,30 @@ onnx_config = dict(
         },
         "num_points_per_voxel": {
             0: "voxels_num",
+        },
+        # "points": {
+        #     0: "num_points",
+        # },
+        "lidar2image": {
+            0: "num_imgs",
+        },
+        "img_aug_matrix": {
+            0: "num_imgs",
+        },
+        "geom_feats": {
+            0: "num_kept",
+        },
+        "kept": {
+            0: "num_geom_feats",
+        },
+        "ranks": {
+            0: "num_kept",
+        },
+        "indices": {
+            0: "num_kept",
+        },
+        "image_feats": {
+            0: "num_imgs",
         },
     },
     input_shape=None,

--- a/projects/BEVFusion/configs/deploy/bevfusion_main_body_with_image_tensorrt_dynamic.py
+++ b/projects/BEVFusion/configs/deploy/bevfusion_main_body_with_image_tensorrt_dynamic.py
@@ -22,7 +22,7 @@ backend_config = dict(
                 coors=dict(min_shape=[1, 3], opt_shape=[64000, 3], max_shape=[256000, 3]),
                 num_points_per_voxel=dict(min_shape=[1], opt_shape=[64000], max_shape=[256000]),
                 # TODO(TIERIV): Optimize. Now, using points will increase latency significantly
-                # points=dict(min_shape=[5000, 4], opt_shape=[50000, 4], max_shape=[200000, 4]),
+                points=dict(min_shape=[5000, 4], opt_shape=[50000, 4], max_shape=[200000, 4]),
                 lidar2image=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
                 img_aug_matrix=dict(min_shape=[1, 4, 4], opt_shape=[6, 4, 4], max_shape=[6, 4, 4]),
                 geom_feats=dict(
@@ -64,7 +64,7 @@ onnx_config = dict(
         "voxels",
         "coors",
         "num_points_per_voxel",
-        # "points",
+        "points",
         "lidar2image",
         "img_aug_matrix",
         "geom_feats",
@@ -84,9 +84,9 @@ onnx_config = dict(
         "num_points_per_voxel": {
             0: "voxels_num",
         },
-        # "points": {
-        #     0: "num_points",
-        # },
+        "points": {
+            0: "num_points",
+        },
         "lidar2image": {
             0: "num_imgs",
         },

--- a/projects/BEVFusion/deploy/containers.py
+++ b/projects/BEVFusion/deploy/containers.py
@@ -14,7 +14,7 @@ class TrtBevFusionImageBackboneContainer(torch.nn.Module):
     def forward(self,imgs):
 
         mod = self.mod
-        imgs = (imgs.unsqueeze(0) - self.images_mean) / self.images_std
+        imgs = (imgs.float().unsqueeze(0) - self.images_mean) / self.images_std
 
         # No lidar augmentations expected during inference.
         return mod.get_image_backbone_features(imgs)[0]

--- a/projects/BEVFusion/deploy/containers.py
+++ b/projects/BEVFusion/deploy/containers.py
@@ -14,10 +14,10 @@ class TrtBevFusionImageBackboneContainer(torch.nn.Module):
     def forward(self,imgs):
 
         mod = self.mod
-        imgs = (imgs - self.images_mean) / self.images_std
+        imgs = (imgs.unsqueeze(0) - self.images_mean) / self.images_std
 
         # No lidar augmentations expected during inference.
-        return mod.get_image_backbone_features(imgs)
+        return mod.get_image_backbone_features(imgs)[0]
 
 
 class TrtBevFusionMainContainer(torch.nn.Module):
@@ -49,7 +49,7 @@ class TrtBevFusionMainContainer(torch.nn.Module):
         }
 
         if points is not None:
-            batch_inputs_dict["points"] = points
+            batch_inputs_dict["points"] = [points]
 
         if image_feats is not None:
 
@@ -57,11 +57,11 @@ class TrtBevFusionMainContainer(torch.nn.Module):
 
             batch_inputs_dict.update(
                 {
-                    "imgs": image_feats,
-                    "lidar2img": lidar2img,
+                    "imgs": image_feats.unsqueeze(0),
+                    "lidar2img": lidar2img.unsqueeze(0),
                     "cam2img": None,
                     "cam2lidar": None,
-                    "img_aug_matrix": img_aug_matrix,
+                    "img_aug_matrix": img_aug_matrix.unsqueeze(0),
                     "img_aug_matrix_inverse": None,
                     "lidar_aug_matrix": lidar_aug_matrix,
                     "lidar_aug_matrix_inverse": lidar_aug_matrix,

--- a/projects/BEVFusion/deploy/containers.py
+++ b/projects/BEVFusion/deploy/containers.py
@@ -11,41 +11,13 @@ class TrtBevFusionImageBackboneContainer(torch.nn.Module):
         self.images_mean = mean
         self.images_std = std
 
-    def forward(
-        self,
-        imgs,
-        points,
-        lidar2image,
-        cam2image,
-        cam2image_inverse,
-        camera2lidar,
-        img_aug_matrix,
-        img_aug_matrix_inverse,
-        lidar_aug_matrix,
-        lidar_aug_matrix_inverse,
-        geom_feats,
-        kept,
-        ranks,
-        indices,
-    ):
+    def forward(self,imgs):
 
         mod = self.mod
         imgs = (imgs - self.images_mean) / self.images_std
 
-        return mod.extract_img_feat(
-            imgs,
-            points,
-            lidar2image,
-            cam2image,
-            camera2lidar,
-            img_aug_matrix,
-            lidar_aug_matrix,
-            img_metas=None,
-            img_aug_matrix_inverse=img_aug_matrix_inverse,
-            camera_intrinsics_inverse=cam2image_inverse,
-            lidar_aug_matrix_inverse=lidar_aug_matrix_inverse,
-            geom_feats=(geom_feats, kept, ranks, indices),
-        )
+        # No lidar augmentations expected during inference.
+        return mod.get_image_backbone_features(imgs)
 
 
 class TrtBevFusionMainContainer(torch.nn.Module):
@@ -53,13 +25,20 @@ class TrtBevFusionMainContainer(torch.nn.Module):
         super().__init__(*args, **kwargs)
         self.mod = mod
 
-    def forward(self, voxels, coors, num_points_per_voxel, image_feats=None):
+    def forward(self, voxels,
+        coors, 
+        num_points_per_voxel,
+        # points = None,
+        lidar2img = None,
+        img_aug_matrix = None,
+        geom_feats = None,
+        kept = None,
+        ranks = None,
+        indices = None,
+        image_feats = None,
+    ):
+
         mod = self.mod
-
-        features = []
-
-        if image_feats is not None:
-            features.append(image_feats)
 
         if coors.shape[1] == 3:
             num_points = coors.shape[0]
@@ -67,26 +46,40 @@ class TrtBevFusionMainContainer(torch.nn.Module):
             batch_coors = torch.zeros(num_points, 1).to(coors.device)
             coors = torch.cat([batch_coors, coors], dim=1).contiguous()
 
-        pts_feature = mod.extract_pts_feat(voxels, coors, num_points_per_voxel)
-        features.append(pts_feature)
+        batch_inputs_dict = {
+            "voxels": {"voxels": voxels, "coors": coors, "num_points_per_voxel": num_points_per_voxel},
+        }
 
-        if mod.fusion_layer is not None:
-            x = mod.fusion_layer(features)
-        else:
-            assert len(features) == 1, features
-            x = features[0]
-        x = mod.pts_backbone(x)
-        x = mod.pts_neck(x)
+        if image_feats is not None:
 
-        outputs = mod.bbox_head(x, None)[0][0]
+            lidar_aug_matrix = torch.eye(4).unsqueeze(0).to(image_feats.device)
 
+            batch_inputs_dict.update(
+                {
+                    "imgs": image_feats,
+                    "lidar2img": lidar2img,
+                    "cam2img": None,
+                    "cam2lidar": None,
+                    "img_aug_matrix": img_aug_matrix,
+                    "img_aug_matrix_inverse": None,
+                    "lidar_aug_matrix": lidar_aug_matrix,
+                    "lidar_aug_matrix_inverse": lidar_aug_matrix,
+                    "geom_feats": (geom_feats, kept, ranks, indices),
+                }
+            )
+
+        outputs = mod._forward(batch_inputs_dict,using_image_features=True)
+
+        # The following code is taken from
+        # projects/BEVFusion/bevfusion/bevfusion_head.py
+        # It is used to simplify the post process in deployment
         score = outputs["heatmap"].sigmoid()
         one_hot = F.one_hot(outputs["query_labels"], num_classes=score.size(1)).permute(0, 2, 1)
         score = score * outputs["query_heatmap_score"] * one_hot
         score = score[0].max(dim=0)[0]
 
         bbox_pred = torch.cat(
-            [outputs["center"][0], outputs["height"][0], outputs["dim"][0], outputs["rot"][0], outputs["vel"][0]],
-            dim=0,
+            [outputs["center"][0], outputs["height"][0], outputs["dim"][0], outputs["rot"][0], outputs["vel"][0]], dim=0
         )
+
         return bbox_pred, score, outputs["query_labels"][0]

--- a/projects/BEVFusion/deploy/containers.py
+++ b/projects/BEVFusion/deploy/containers.py
@@ -28,7 +28,7 @@ class TrtBevFusionMainContainer(torch.nn.Module):
     def forward(self, voxels,
         coors, 
         num_points_per_voxel,
-        # points = None,
+        points = None,
         lidar2img = None,
         img_aug_matrix = None,
         geom_feats = None,
@@ -37,9 +37,7 @@ class TrtBevFusionMainContainer(torch.nn.Module):
         indices = None,
         image_feats = None,
     ):
-
         mod = self.mod
-
         if coors.shape[1] == 3:
             num_points = coors.shape[0]
             coors = coors.flip(dims=[-1]).contiguous()  # [x, y, z]
@@ -49,6 +47,9 @@ class TrtBevFusionMainContainer(torch.nn.Module):
         batch_inputs_dict = {
             "voxels": {"voxels": voxels, "coors": coors, "num_points_per_voxel": num_points_per_voxel},
         }
+
+        if points is not None:
+            batch_inputs_dict["points"] = points
 
         if image_feats is not None:
 

--- a/projects/BEVFusion/deploy/torch2onnx.py
+++ b/projects/BEVFusion/deploy/torch2onnx.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
             images_mean = data_preprocessor.mean.to(device)
             images_std = data_preprocessor.std.to(device)
             image_backbone_container = TrtBevFusionImageBackboneContainer(patched_model, images_mean, images_std)
-            model_inputs = (imgs.unsqueeze(0).to(device).float(),)
+            model_inputs = (imgs.to(device).float(),)
             
             if args.module == "image_backbone":
                 return_value = torch.onnx.export(
@@ -208,9 +208,9 @@ if __name__ == "__main__":
             )
             if image_feats is not None:
                 model_inputs += (
-                    points.unsqueeze(0).to(device).float(),
-                    lidar2img.unsqueeze(0).to(device).float(),
-                    img_aug_matrix.unsqueeze(0).to(device).float(),
+                    points.to(device).float(),
+                    lidar2img.to(device).float(),
+                    img_aug_matrix.to(device).float(),
                     geom_feats.to(device).float(),
                     kept.to(device),
                     ranks.to(device).long(),

--- a/projects/BEVFusion/deploy/torch2onnx.py
+++ b/projects/BEVFusion/deploy/torch2onnx.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
             images_mean = data_preprocessor.mean.to(device)
             images_std = data_preprocessor.std.to(device)
             image_backbone_container = TrtBevFusionImageBackboneContainer(patched_model, images_mean, images_std)
-            model_inputs = (imgs.to(device).float(),)
+            model_inputs = (imgs.to(device=device,dtype=torch.uint8),)
             
             if args.module == "image_backbone":
                 return_value = torch.onnx.export(

--- a/projects/BEVFusion/deploy/torch2onnx.py
+++ b/projects/BEVFusion/deploy/torch2onnx.py
@@ -208,19 +208,19 @@ if __name__ == "__main__":
             )
             if image_feats is not None:
                 model_inputs += (
-                    # points.unsqueeze(0).to(device).float(),    # TODO(TIERIV): Optimize. Now, using points will increase latency significantly
+                    points.unsqueeze(0).to(device).float(),
                     lidar2img.unsqueeze(0).to(device).float(),
                     img_aug_matrix.unsqueeze(0).to(device).float(),
                     geom_feats.to(device).float(),
                     kept.to(device),
                     ranks.to(device).long(),
                     indices.to(device).long(),
-                    image_feats,
+                    image_feats
                 )
             torch.onnx.export(
                 main_container,
                 model_inputs,
-                output_path.replace(".onnx", "_tofix.onnx"),
+                output_path.replace(".onnx", "_temp_to_be_fixed.onnx"),
                 export_params=True,
                 input_names=input_names,
                 output_names=output_names,
@@ -235,7 +235,7 @@ if __name__ == "__main__":
 
             import onnx_graphsurgeon as gs
 
-            model = onnx.load(output_path.replace(".onnx", "_tofix.onnx"))
+            model = onnx.load(output_path.replace(".onnx", "_temp_to_be_fixed.onnx"))
             graph = gs.import_onnx(model)
 
             # Fix TopK


### PR DESCRIPTION
This pull request introduces significant improvements to the BEVFusion deployment pipeline, particularly for ONNX/TensorRT export and dynamic input support. The changes focus on refactoring the model's forward and feature extraction logic to better handle image features, updating deployment configs for more flexible input shapes, and fixing geometry computation in the depth module. These updates enhance the modularity and exportability of the BEVFusion model, facilitating more efficient deployment and inference.

**Model code refactoring and ONNX export support:**

* Refactored `BEVFusion` model methods (`_forward`, `predict`, `loss`, and `extract_feat`) to consistently accept a new `using_image_features` flag, improving control over whether to use precomputed image features during inference or export. Added a new `get_image_backbone_features` helper to modularize image feature extraction. [[1]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bL60-R60) [[2]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bL69-R69) [[3]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR125-R139) [[4]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR154-R158) [[5]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bL222-R230) [[6]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bL249-R257) [[7]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR270-R277) [[8]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR304-R342) [[9]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bL349-R361)

* Updated the logic in `extract_feat` to handle ONNX inference mode, including geometry feature handling and disabling point features when necessary. [[1]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR270-R277) [[2]](diffhunk://#diff-4daedff714f228a95b5d6ffedf60fc360caa87193eaa16debe503545c466db1bR304-R342)

**Deployment configuration updates:**

* Updated `bevfusion_camera_backbone_tensorrt_dynamic.py` and `bevfusion_main_body_with_image_tensorrt_dynamic.py` to use more flexible and parameterized input shapes (e.g., `image_dims`, `depth_bins`, `feature_dims`). Expanded the set of dynamic axes and input names to support a wider range of deployment scenarios, and added missing inputs required for the main body with image features. [[1]](diffhunk://#diff-f23f1c24b326823bf45fb93102ebc252dbe63b9cb93688c49c6ff3709b2c0a6eR12-R20) [[2]](diffhunk://#diff-f23f1c24b326823bf45fb93102ebc252dbe63b9cb93688c49c6ff3709b2c0a6eL60-R40) [[3]](diffhunk://#diff-bca782b38ed30673228daa6e23873dbedf4a73f516f95158796765d54f6a6cfcR12-R14) [[4]](diffhunk://#diff-bca782b38ed30673228daa6e23873dbedf4a73f516f95158796765d54f6a6cfcL21-R51) [[5]](diffhunk://#diff-bca782b38ed30673228daa6e23873dbedf4a73f516f95158796765d54f6a6cfcL33-R75) [[6]](diffhunk://#diff-bca782b38ed30673228daa6e23873dbedf4a73f516f95158796765d54f6a6cfcR87-R110)

* Adjusted `bevfusion_main_body_lidar_only_tensorrt_dynamic.py` to update the expected voxel and coordinate shapes for lidar-only inference.

**Depth module geometry computation fix:**

* Fixed the placement of geometry computation logic in `depth_lss.py`, ensuring that transformations and matrix inverses are only computed when not using precomputed geometry features. [[1]](diffhunk://#diff-83bee0ac305507a6ebb98f73f2f2b835cc3a9b5a66a98892557f3329d82a862fL317-L330) [[2]](diffhunk://#diff-83bee0ac305507a6ebb98f73f2f2b835cc3a9b5a66a98892557f3329d82a862fR395-R408)

**Documentation updates:**

* Updated `README.md` deployment command examples to include the `--module` argument, clarifying how to export specific model components. [[1]](diffhunk://#diff-6ad877c689db4f1aaa29bce4cfad070bb06addc6947c184b9c5662cd27cef8b6L134-R134) [[2]](diffhunk://#diff-6ad877c689db4f1aaa29bce4cfad070bb06addc6947c184b9c5662cd27cef8b6L143-R143)