### PR TITLE
chore(DOCKER): Fix library transformers version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN python3 -m pip install git+https://github.com/tier4/autoware_perception_eval
 
 # Need to dowgrade setuptools to 60.2.0 to fix setup
 RUN python3 -m pip --no-cache-dir install \
-    setuptools==60.2.0
+    setuptools==60.2.0 \
+    transformers==4.51.3
 
 # NOTE(knzo25): this patch is needed to use numpy versions over 1.23.5 (version used in mmdet3d 1.4.0)
 # It can be safely deleted when mmdet3d updates the numpy version


### PR DESCRIPTION
## Summary

Fix the library: `transformers` to a version: `4.51.3` to align with mmdetection
