### PR TITLE
fix(streampetr): fix parameter name to use_bottom_center

### DIFF
--- a/projects/StreamPETR/configs/default/resnet50_480x640_baseline.py
+++ b/projects/StreamPETR/configs/default/resnet50_480x640_baseline.py
@@ -123,7 +123,7 @@ model = dict(
         split=0.75,  ###positive rate
         LID=True,
         with_position=True,
-        use_gravity_center=False,
+        use_bottom_center=False,
         position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
         code_weights=[
             2.0,

--- a/projects/StreamPETR/configs/default/vov_flash_480x640_baseline.py
+++ b/projects/StreamPETR/configs/default/vov_flash_480x640_baseline.py
@@ -121,7 +121,7 @@ model = dict(
         split=0.75,  ###positive rate
         LID=True,
         with_position=True,
-        use_gravity_center=False,
+        use_bottom_center=False,
         position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
         code_weights=[
             2.0,

--- a/projects/StreamPETR/configs/nuscenes/nuscenes_resnet50_320x800_baseline.py
+++ b/projects/StreamPETR/configs/nuscenes/nuscenes_resnet50_320x800_baseline.py
@@ -132,7 +132,7 @@ model = dict(
         split=0.75,  ###positive rate
         LID=True,
         with_position=True,
-        use_gravity_center=True,
+        use_bottom_center=True,
         position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
         code_weights=[
             2.0,

--- a/projects/StreamPETR/configs/nuscenes/nuscenes_vov_flash_320x800_baseline.py
+++ b/projects/StreamPETR/configs/nuscenes/nuscenes_vov_flash_320x800_baseline.py
@@ -131,7 +131,7 @@ model = dict(
         split=0.75,  ###positive rate
         LID=True,
         with_position=True,
-        use_gravity_center=True,
+        use_bottom_center=True,
         position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
         code_weights=[
             2.0,

--- a/projects/StreamPETR/stream_petr/models/dense_heads/streampetr_head.py
+++ b/projects/StreamPETR/stream_petr/models/dense_heads/streampetr_head.py
@@ -119,7 +119,7 @@ class StreamPETRHead(AnchorFreeHead):
         split=0.5,
         init_cfg=None,
         normedlinear=False,
-        use_gravity_center=False,
+        use_bottom_center=False,
         **kwargs,
     ):
         # NOTE here use `AnchorFreeHead` instead of `TransformerHead`,
@@ -236,7 +236,7 @@ class StreamPETRHead(AnchorFreeHead):
 
         self._init_layers()
         self.reset_memory()
-        self.use_gravity_center = use_gravity_center
+        self.use_bottom_center = use_bottom_center
 
     def _init_layers(self):
         """Initialize layers of the transformer head."""
@@ -1087,7 +1087,7 @@ class StreamPETRHead(AnchorFreeHead):
         for i in range(num_samples):
             preds = preds_dicts[i]
             bboxes = preds["bboxes"]
-            if self.use_gravity_center:
+            if self.use_bottom_center:
                 bboxes[:, 2] = bboxes[:, 2] - bboxes[:, 5] * 0.5  # This returns the gravity centers
             scores = preds["scores"]
             labels = preds["labels"]

--- a/projects/StreamPETR/stream_petr/models/dense_heads/streampetr_head.py
+++ b/projects/StreamPETR/stream_petr/models/dense_heads/streampetr_head.py
@@ -1088,7 +1088,7 @@ class StreamPETRHead(AnchorFreeHead):
             preds = preds_dicts[i]
             bboxes = preds["bboxes"]
             if self.use_bottom_center:
-                bboxes[:, 2] = bboxes[:, 2] - bboxes[:, 5] * 0.5  # This returns the gravity centers
+                bboxes[:, 2] = bboxes[:, 2] - bboxes[:, 5] * 0.5  # This returns the bottom centers
             scores = preds["scores"]
             labels = preds["labels"]
 


### PR DESCRIPTION
This pull request refactors the codebase to replace the `use_gravity_center` option with `use_bottom_center` throughout the StreamPETR configuration files and model head implementation. The logic and parameter names are updated to consistently use "bottom center" terminology instead of "gravity center," aligning the code with the intended behavior for bounding box center calculations.

**Parameter renaming and logic update:**

* Replaced all occurrences of the `use_gravity_center` parameter with `use_bottom_center` in the `streampetr_head.py` model head, updating both the constructor and internal variable usage. [[1]](diffhunk://#diff-8e6ea5162d1e3ec895263a88c62e811e215bc4a752c7a7cf83a713906251b35bL122-R122) [[2]](diffhunk://#diff-8e6ea5162d1e3ec895263a88c62e811e215bc4a752c7a7cf83a713906251b35bL239-R239)
* Updated the bounding box center calculation logic in `get_bboxes` to use `use_bottom_center` instead of `use_gravity_center`, ensuring the correct center is computed.

**Configuration updates:**

* Changed the relevant configuration files to use `use_bottom_center` instead of `use_gravity_center` for all model variants, ensuring consistency across experimental setups:
  - `resnet50_480x640_baseline.py` and `vov_flash_480x640_baseline.py` [[1]](diffhunk://#diff-51e90b74ca05cc679a366f06f81bd3809f6351b142f26a13991eebb12859adefL126-R126) [[2]](diffhunk://#diff-7950911ed7bc1b146bed317536be0bee9483e161637fd61e6228078787b5f195L124-R124)
  - `nuscenes_resnet50_320x800_baseline.py` and `nuscenes_vov_flash_320x800_baseline.py` [[1]](diffhunk://#diff-49275b07e3b756e200b2094f620d565d0205cfae1c6267804474973e779dfd90L135-R135) [[2]](diffhunk://#diff-2e62b2e373ec03197358ba2895d5117b78f515d37d3805cc794bcbce2ae4a167L134-R134)