### PR TITLE
chore(webauto): fix webauto version to 0.50.0

### DIFF
--- a/pipelines/webauto/README.md
+++ b/pipelines/webauto/README.md
@@ -2,7 +2,7 @@
 # Pipeline with WebAuto
 
 This is the tools to use `AWML` with WebAuto.
-You check data access right of [WebAuto(> v0.40.0)](https://docs.web.auto/en/user-manuals/).
+You check data access right of [WebAuto(==v0.50.0)](https://docs.web.auto/en/user-manuals/).
 
 - [Support priority](https://github.com/tier4/AWML/blob/main/docs/design/autoware_ml_design.md#support-priority): Write for each tools
 

--- a/pipelines/webauto/README.md
+++ b/pipelines/webauto/README.md
@@ -2,7 +2,7 @@
 # Pipeline with WebAuto
 
 This is the tools to use `AWML` with WebAuto.
-You check data access right of [WebAuto(==v0.50.0)](https://docs.web.auto/en/user-manuals/).
+You check data access right of [WebAuto(>=v0.50.0)](https://docs.web.auto/en/user-manuals/).
 
 - [Support priority](https://github.com/tier4/AWML/blob/main/docs/design/autoware_ml_design.md#support-priority): Write for each tools
 

--- a/pipelines/webauto/download_t4dataset/README.md
+++ b/pipelines/webauto/download_t4dataset/README.md
@@ -8,7 +8,7 @@ You can download T4dataset by script using WebAuto CLI.
 
 - This script do not need docker environment and is tested by Ubuntu22.04 LTS environment.
 - Download WebAuto CLI and setup as [the document](https://docs.web.auto/en/developers-guides/quick-start)
-- You check data access right of [WebAuto(> v0.33.1)](https://docs.web.auto/en/user-manuals/).
+- You check data access right of [WebAuto(== v0.50.0)](https://docs.web.auto/en/user-manuals/).
 
 ## Get started
 

--- a/pipelines/webauto/download_t4dataset/README.md
+++ b/pipelines/webauto/download_t4dataset/README.md
@@ -7,8 +7,8 @@ You can download T4dataset by script using WebAuto CLI.
 ## Environment
 
 - This script do not need docker environment and is tested by Ubuntu22.04 LTS environment.
-- Download WebAuto CLI(v0.50.0) and setup as [the document](https://docs.web.auto/en/developers-guides/quick-start)
-- You check data access right of [WebAuto(== v0.50.0)](https://docs.web.auto/en/user-manuals/).
+- Download WebAuto CLI(>=v0.50.0) and setup as [the document](https://docs.web.auto/en/developers-guides/quick-start)
+- You check data access right of [WebAuto(>=v0.50.0)](https://docs.web.auto/en/user-manuals/).
 
 ## Get started
 

--- a/pipelines/webauto/download_t4dataset/README.md
+++ b/pipelines/webauto/download_t4dataset/README.md
@@ -7,7 +7,7 @@ You can download T4dataset by script using WebAuto CLI.
 ## Environment
 
 - This script do not need docker environment and is tested by Ubuntu22.04 LTS environment.
-- Download WebAuto CLI and setup as [the document](https://docs.web.auto/en/developers-guides/quick-start)
+- Download WebAuto CLI(v0.50.0) and setup as [the document](https://docs.web.auto/en/developers-guides/quick-start)
 - You check data access right of [WebAuto(== v0.50.0)](https://docs.web.auto/en/user-manuals/).
 
 ## Get started

--- a/pipelines/webauto/download_t4dataset/download_t4dataset.py
+++ b/pipelines/webauto/download_t4dataset/download_t4dataset.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import os
 import re
-
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -36,15 +35,15 @@ def check_webauto_version(webauto_path: str) -> None:
         raise Exception(f"Failed to get webauto version. {result.stderr.decode('utf-8')}")
 
     version_output = result.stdout.decode("utf-8").strip()
-    
+
     # Extract version from output (assuming format like "webauto v0.50.0" or just "v0.50.0")
-    version_match = re.search(r'v?(\d+\.\d+\.\d+)', version_output)
+    version_match = re.search(r"v?(\d+\.\d+\.\d+)", version_output)
     if not version_match:
         raise Exception(f"Could not parse version from webauto output: {version_output}")
-    
+
     current_version = version_match.group(1)
-    required_version = WEBAUTO_VERSION.lstrip('v')  # Remove 'v' prefix if present
-    
+    required_version = WEBAUTO_VERSION.lstrip("v")  # Remove 'v' prefix if present
+
     if version.parse(current_version) < version.parse(required_version):
         raise Exception(f"Webauto version {current_version} is below required version {required_version}")
 

--- a/pipelines/webauto/download_t4dataset/download_t4dataset.py
+++ b/pipelines/webauto/download_t4dataset/download_t4dataset.py
@@ -14,6 +14,30 @@ from typing import Union
 import yaml
 
 
+# Required webauto version
+WEBAUTO_VERSION = "v0.50.0"
+
+
+def check_webauto_version(webauto_path: str) -> None:
+    """
+    Check if the webauto version matches the required version.
+    
+    Args:
+        webauto_path (str): The path to WebAutoCLI.
+    
+    Raises:
+        Exception: If webauto version check fails or doesn't match required version.
+    """
+    command = f"{webauto_path} --version"
+    result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        raise Exception(f"Failed to get webauto version. {result.stderr.decode('utf-8')}")
+    
+    version_output = result.stdout.decode("utf-8")
+    if WEBAUTO_VERSION not in version_output:
+        raise Exception(f"Webauto version is not {WEBAUTO_VERSION}. Found: {version_output.strip()}")
+
+
 def get_t4dataset_ids(config_path: str) -> list[str]:
     """
     Get T4Dataset IDs like "0df0328e-39ea-42f1-844a-b455c91dc6cc".
@@ -262,6 +286,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    # Check webauto version before proceeding
+    check_webauto_version(args.webauto_path)
 
     config_path = Path(args.config)
     assert config_path.exists() and config_path.is_file()

--- a/pipelines/webauto/download_t4dataset/download_t4dataset.py
+++ b/pipelines/webauto/download_t4dataset/download_t4dataset.py
@@ -13,7 +13,6 @@ from typing import Union
 
 import yaml
 
-
 # Required webauto version
 WEBAUTO_VERSION = "v0.50.0"
 
@@ -21,10 +20,10 @@ WEBAUTO_VERSION = "v0.50.0"
 def check_webauto_version(webauto_path: str) -> None:
     """
     Check if the webauto version matches the required version.
-    
+
     Args:
         webauto_path (str): The path to WebAutoCLI.
-    
+
     Raises:
         Exception: If webauto version check fails or doesn't match required version.
     """
@@ -32,7 +31,7 @@ def check_webauto_version(webauto_path: str) -> None:
     result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
         raise Exception(f"Failed to get webauto version. {result.stderr.decode('utf-8')}")
-    
+
     version_output = result.stdout.decode("utf-8")
     if WEBAUTO_VERSION not in version_output:
         raise Exception(f"Webauto version is not {WEBAUTO_VERSION}. Found: {version_output.strip()}")

--- a/pipelines/webauto/download_t4dataset/download_t4dataset.py
+++ b/pipelines/webauto/download_t4dataset/download_t4dataset.py
@@ -6,12 +6,15 @@ Setup a tool and configuration following <https://github.com/tier4/WebAutoCLI>.
 import argparse
 import json
 import os
+import re
+
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Union
 
 import yaml
+from packaging import version
 
 # Required webauto version
 WEBAUTO_VERSION = "v0.50.0"
@@ -19,22 +22,31 @@ WEBAUTO_VERSION = "v0.50.0"
 
 def check_webauto_version(webauto_path: str) -> None:
     """
-    Check if the webauto version matches the required version.
+    Check if the webauto version is >= the required version.
 
     Args:
         webauto_path (str): The path to WebAutoCLI.
 
     Raises:
-        Exception: If webauto version check fails or doesn't match required version.
+        Exception: If webauto version check fails or is below required version.
     """
     command = f"{webauto_path} --version"
     result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
         raise Exception(f"Failed to get webauto version. {result.stderr.decode('utf-8')}")
 
-    version_output = result.stdout.decode("utf-8")
-    if WEBAUTO_VERSION not in version_output:
-        raise Exception(f"Webauto version is not {WEBAUTO_VERSION}. Found: {version_output.strip()}")
+    version_output = result.stdout.decode("utf-8").strip()
+    
+    # Extract version from output (assuming format like "webauto v0.50.0" or just "v0.50.0")
+    version_match = re.search(r'v?(\d+\.\d+\.\d+)', version_output)
+    if not version_match:
+        raise Exception(f"Could not parse version from webauto output: {version_output}")
+    
+    current_version = version_match.group(1)
+    required_version = WEBAUTO_VERSION.lstrip('v')  # Remove 'v' prefix if present
+    
+    if version.parse(current_version) < version.parse(required_version):
+        raise Exception(f"Webauto version {current_version} is below required version {required_version}")
 
 
 def get_t4dataset_ids(config_path: str) -> list[str]:


### PR DESCRIPTION
This pull request updates the WebAuto integration in the T4dataset download pipeline to require and enforce the use of WebAuto CLI version v0.50.0. Documentation and code have been updated to reflect and enforce this version requirement, ensuring compatibility and reducing user confusion.

**Documentation updates:**

* Updated all relevant documentation (`README.md` files) to specify that WebAuto CLI version v0.50.0 is required, replacing previous version requirements. [[1]](diffhunk://#diff-a69c4fee4573957b9543cfa4788489bbde85fda11592220492667b084bd3f543L5-R5) [[2]](diffhunk://#diff-b8feb25ffdc24a918447ca3adae660eb4c222c7b1a2b1713b48a48581914258bL10-R11)

**Code changes for version enforcement:**

* Added a `check_webauto_version` function to `download_t4dataset.py` that checks if the installed WebAuto CLI matches the required v0.50.0 version and raises an exception if not.
* Integrated the version check into the `main()` function of `download_t4dataset.py` to ensure the script halts if the wrong version is detected.