### PR TITLE
fix(BEVFusion): Fix bev pool double indices

### DIFF
--- a/projects/BEVFusion/bevfusion/depth_lss.py
+++ b/projects/BEVFusion/bevfusion/depth_lss.py
@@ -152,7 +152,7 @@ class BaseViewTransform(nn.Module):
 
         assert x.shape[0] == geom_feats.shape[0]
 
-        x, geom_feats, ranks = x[indices], geom_feats[indices], ranks[indices]
+        x = x[indices]
 
         x = bev_pool(x, geom_feats, ranks, B, self.nx[2], self.nx[0], self.nx[1], self.training)
 

--- a/projects/BEVFusion/bevfusion/transforms_3d.py
+++ b/projects/BEVFusion/bevfusion/transforms_3d.py
@@ -80,8 +80,8 @@ class ImageAug3D(BaseTransform):
         imgs = data["img"]
         new_imgs = []
         transforms = []
+        resize, resize_dims, crop, flip, rotate = self.sample_augmentation(data)
         for img in imgs:
-            resize, resize_dims, crop, flip, rotate = self.sample_augmentation(data)
             post_rot = torch.eye(2)
             post_tran = torch.zeros(2)
             new_img, rotation, translation = self.img_transform(


### PR DESCRIPTION
## Summary

1. Fix double indices of `geom_feats` and `ranks` in `bev_pool` [[1]](https://github.com/tier4/AWML/pull/128/files#diff-83bee0ac305507a6ebb98f73f2f2b835cc3a9b5a66a98892557f3329d82a862fL155)
2. Make training augmentation consistent across the same set of scene [[2]](https://github.com/tier4/AWML/pull/128/files#diff-a40de9d976eee70a128aac7ca0e89a6a67994ff4759ca57700b6526f9a571c29L84)

