### PR TITLE
fix(BEVFusion): fix dataset name for J6Gen2

### DIFF
--- a/projects/BEVFusion/configs/t4dataset/BEVFusion-CL/bevfusion_camera_lidar_voxel_second_secfpn_4xb8_gen2_base.py
+++ b/projects/BEVFusion/configs/t4dataset/BEVFusion-CL/bevfusion_camera_lidar_voxel_second_secfpn_4xb8_gen2_base.py
@@ -1,6 +1,6 @@
 _base_ = [
     "../default/bevfusion_lidar_voxel_second_secfpn_1xb1_t4base.py",
-    "../../../../../autoware_ml/configs/detection3d/dataset/t4dataset/gen2_base.py",
+    "../../../../../autoware_ml/configs/detection3d/dataset/t4dataset/j6gen2_base.py",
 ]
 
 custom_imports = dict(imports=["projects.BEVFusion.bevfusion"], allow_failed_imports=False)


### PR DESCRIPTION
## Summary

I fixed the wrong name `gen2_base.py` to correct name `j6gen2_base.py`

## Change point

- fix(BEVFusion): fix dataset name for J6Gen2

## Note

This influences for BEVFusion project only.

## Test performed

I checked that this config works with `auto_labeling_3d`
