### PR TITLE
feat(Transform): Add a data augmentation to support filter 3D objects based on different range and number of points

### DIFF
--- a/autoware_ml/detection3d/datasets/transforms/object_min_points_filter.py
+++ b/autoware_ml/detection3d/datasets/transforms/object_min_points_filter.py
@@ -98,9 +98,12 @@ class ObjectRangeMinPointsFilter(BaseTransform):
         out_of_range_gt_masks = ~bev_radius_mask
 
         points = input_dict["points"]
-        # TODO(kminoda): There is a scary comment in the original code:
-        # # TODO: this function is different from PointCloud3D, be careful
-        # # when start to use nuscene, check the input
+        # NOTE: box_np_ops.points_in_rbbox may differ from PointCloud3D in terms of input format and output mask shape.
+        # For nuScenes compatibility, ensure that:
+        # - The input points are in the expected coordinate system (e.g., lidar vs. camera coordinates).
+        # - The bounding box tensor shape matches the expected format (N, 7) for [x, y, z, dx, dy, dz, heading].
+        # - The output mask correctly identifies points inside each bounding box for nuScenes data.
+        # See https://github.com/open-mmlab/mmdetection3d/blob/main/mmdet3d/structures/ops/box_np_ops.py for details.
         indices = box_np_ops.points_in_rbbox(
             points.tensor.numpy()[:, :3],
             gt_bboxes_3d.tensor.numpy()[:, :7],


### PR DESCRIPTION
## Summary
Add `ObjectRangeMinPointsFilter` to filter 3D objects based on a bev range and number of minimum points in a 3d bounding box [[1]](https://github.com/tier4/AWML/compare/feat/add_distance_base_object_range_filter?expand=1#diff-67ded712e98b2231ada4e7c2869500bc91df39e4cce866bed372612ff88f9199R52)

## Examples

To use the data augmentation, please add the following to a train/test pipeline:
```python
train_pipeline = [
...
    dict(type="ObjectRangeMinPointsFilter", range_radius=[0, 60], min_num_points=2),
    dict(type="ObjectRangeMinPointsFilter", range_radius=[60, 130], min_num_points=1),
...
```