### PR TITLE
fix(t4dataset): fix lidar2ego in info file

### DIFF
--- a/tools/detection3d/t4dataset_converters/t4converter.py
+++ b/tools/detection3d/t4dataset_converters/t4converter.py
@@ -117,9 +117,13 @@ def get_lidar_sweeps_info(
             lidar2sensor[:3, :3] = rot.T
             lidar2sensor[:3, 3:4] = -1 * np.matmul(rot.T, trans.reshape(3, 1))
 
-            lidar2ego = np.eye(4)
-            lidar2ego[:3, :3] = rot
-            lidar2ego[:3, 3] = trans
+            # lidar2ego must be the sweep frame's mounting extrinsic, not the
+            # sweep->key transform; consumers composing ego poses with this
+            # field would otherwise apply ego motion twice.
+            lidar2ego = convert_quaternion_to_matrix(
+                quaternion=v1_sweep["sensor2ego_rotation"],
+                translation=v1_sweep["sensor2ego_translation"],
+            )
             lidar_path = v1_sweep["data_path"]
 
             mmengine.check_file_exist(lidar_path)


### PR DESCRIPTION
## Description

Fixes the `lidar2ego` field written into the `lidar_sweeps` entries of the
detection3d info files (`create_data_t4dataset.py` → `get_lidar_sweeps_info`).

## Problem

`lidar2ego` for each sweep was built from `sensor2lidar_rotation` /
`sensor2lidar_translation`, which is the **sweep → key-frame** transform
(`sweep → ego → global → ego' → key lidar`) and therefore already contains
ego motion between the sweep and the key frame.

Semantically, `lidar2ego` must be the sweep frame's **static mounting
extrinsic** (`calibrated_sensor`, i.e. `sensor2ego`). Consumers that compose
the standard chain
Write what you change and why you change

## Related Link
https://github.com/tier4/autoware-ml/pull/82
