### PR TITLE
fix(t4metric_v2): filter GT by annotation num_lidar_pts

### DIFF
--- a/autoware_ml/detection3d/evaluation/t4metric/t4metric_v2.py
+++ b/autoware_ml/detection3d/evaluation/t4metric/t4metric_v2.py
@@ -11,7 +11,6 @@ import numpy as np
 import torch
 from mmdet3d.registry import METRICS
 from mmdet3d.structures import LiDARInstance3DBoxes
-from mmdet3d.structures.ops import box_np_ops
 from mmengine.dist import get_world_size
 from mmengine.evaluator import BaseMetric
 from mmengine.logging import MessageHub, MMLogger
@@ -438,11 +437,10 @@ class T4MetricV2(BaseMetric):
             # Skip processing if result pickle already exists
             return
 
-        batch_points = data_batch["inputs"]["points"]
-        for data_sample, points in zip(data_samples, batch_points):
+        for data_sample in data_samples:
             current_time = data_sample["timestamp"]
             scene_id = self._parse_scene_id(data_sample["lidar_path"])
-            frame_ground_truth = self._parse_ground_truth_from_sample(current_time, data_sample, points)
+            frame_ground_truth = self._parse_ground_truth_from_sample(current_time, data_sample)
             perception_frame = self._parse_predictions_from_sample(current_time, data_sample, frame_ground_truth)
             self._save_perception_frame(scene_id, data_sample["sample_idx"], perception_frame)
 
@@ -1384,7 +1382,7 @@ class T4MetricV2(BaseMetric):
         except ValueError:
             return _UNKNOWN
 
-    def _parse_ground_truth_from_sample(self, time: float, data_sample: Dict[str, Any], points) -> FrameGroundTruth:
+    def _parse_ground_truth_from_sample(self, time: float, data_sample: Dict[str, Any]) -> FrameGroundTruth:
         """Parses ground truth objects from the given data sample.
 
         Args:
@@ -1415,10 +1413,10 @@ class T4MetricV2(BaseMetric):
         num_lidar_pts: np.ndarray = eval_info.get("num_lidar_pts", np.array([]))
 
         if self.min_num_points > 0 and len(bboxes):
-            points_cpu = points.cpu().numpy()
-            indices = box_np_ops.points_in_rbbox(points_cpu[:, :3], bboxes[:, :7])
-            num_points_in_gt = indices.sum(0)
-            bboxes_mask = num_points_in_gt >= self.min_num_points
+            # Filter by the annotation's keyframe point count (nuScenes/Waymo convention)
+            # so the evaluation GT set stays independent of the model input pipeline
+            # (sweep count, remove_close, range filter).
+            bboxes_mask = num_lidar_pts >= self.min_num_points
             bboxes = bboxes[bboxes_mask]
             gt_labels_3d = gt_labels_3d[bboxes_mask]
             num_lidar_pts = num_lidar_pts[bboxes_mask]


### PR DESCRIPTION
# IMPORTANT
Don't merge this PR since we are moving to autoware-ml.

## What

`T4MetricV2`'s `min_num_points` GT filter recomputed per-box point counts with
`points_in_rbbox` on the **model input point cloud** (multi-sweep concatenation,
after `remove_close` and range filtering). This PR changes it to use the
annotation `num_lidar_pts` stored in the info pkl (keyframe count, the
nuScenes/Waymo convention).

## Why

Recomputing on the input cloud couples the evaluation GT set to the model input
pipeline:

- Changing the sweep count or any point-cloud preprocessing changes **which GT
  boxes are evaluated**, so runs with different input configs are not comparable
  (an experiment that improves detection can show a lower mAP simply because its
  input config resurrects harder GT boxes).
- Sweep accumulation is ego-motion compensated but **not object-motion
  compensated**, so the recomputed counts are physically wrong for moving
  objects (smeared points fall outside the box).
- Preprocessing artifacts (`remove_close`, range filter) remove points from
  boxes that the sensor actually observed, wrongly excluding them from GT.

The benchmark GT should be a fixed property of the dataset, not of the model
config. Note that the **training-side** filters (`ObjectMinPointsFilter`)
intentionally keep recomputing on the input cloud — that is a training
hyperparameter and is not changed here.

## Verification

On the BEVFusion-L `j6gen2_base` val split (3,645 frames, kokseang_2_8_1 infos):

- The `num_lidar_pts` field is fully populated (209,759 instances, 0 missing;
  17.5 % zero-point boxes from interpolated annotations are correctly dropped
  by `min_num_points=2`).
- The filtered GT set now matches an independent implementation
  (autoware-ml detection metric suite) class by class
  (car 92,351 / bus 3,755 / bicycle 2,456 / pedestrian 35,186 /
  traffic_cone 3,583 / barrier 524).
- 0–121 m mAP moves 0.6518 → 0.6499 and now agrees with the independent
  implementation to ±0.0004 (was −0.006 before this fix).

Side benefit: removes one `points_in_rbbox` call per frame from evaluation.